### PR TITLE
fix(Dockerfile,Makefile,glide.yaml,glide.lock): dockerize the dev and test environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu-debootstrap:14.04
+
+COPY tests/tests.test .
+RUN mv tests.test /bin
+RUN apt-get update -y && apt-get install -y curl
+RUN curl -sSL http://deis.io/deis-cli/install-v2-alpha.sh | bash && mv ./deis /bin/deis
+CMD tests/tests.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM ubuntu-debootstrap:14.04
 
 COPY tests/tests.test .
 RUN mv tests.test /bin
-RUN apt-get update -y && apt-get install -y curl
+RUN apt-get update -y && apt-get install -y curl openssh-client git build-essential
 RUN curl -sSL http://deis.io/deis-cli/install-v2-alpha.sh | bash && mv ./deis /bin/deis
 CMD /bin/tests.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM ubuntu-debootstrap:14.04
 
 COPY tests/tests.test .
 RUN mv tests.test /bin
-RUN apt-get update -y && apt-get install -y curl openssh-client git build-essential
+RUN apt-get update -y && apt-get install -y curl openssh-client git
 RUN curl -sSL http://deis.io/deis-cli/install-v2-alpha.sh | bash && mv ./deis /bin/deis
 CMD /bin/tests.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ COPY tests/tests.test .
 RUN mv tests.test /bin
 RUN apt-get update -y && apt-get install -y curl
 RUN curl -sSL http://deis.io/deis-cli/install-v2-alpha.sh | bash && mv ./deis /bin/deis
-CMD tests/tests.test
+CMD /bin/tests.test

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,35 @@
+export GO15VENDOREXPERIMENT=1
 
-test-setup:
-	go get github.com/onsi/ginkgo/ginkgo
-	go get github.com/onsi/gomega
+SHORT_NAME := deis-e2e
+
+SRC_PATH := /go/src/github.com/deis/workflow/_tests
+DEV_IMG := quay.io/deis/go-dev:0.4.0
+DEIS_WORKFLOW_SERVICE_HOST ?= deis.172.17.8.100:8080
+
+RUN_CMD := docker run --rm -e DEIS_WORKFLOW_SERVICE_HOST=${DEIS_WORKFLOW_SERVICE_HOST} -v ${CURDIR}:${SRC_PATH} -w ${SRC_PATH} ${DEV_IMG}
+DEV_CMD := docker run --rm -e GO15VENDOREXPERIMENT=1 -v ${CURDIR}:${SRC_PATH} -w ${SRC_PATH} ${DEV_IMG}
+
+VERSION ?= git-$(shell git rev-parse --short HEAD)
+DEIS_REGISTRY ?= quay.io/
+IMAGE_PREFIX ?= deis
+IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/${SHORT_NAME}:${VERSION}
+
+bootstrap:
+	${DEV_CMD} glide install
 
 test-integration:
 	go test ./tests/... -v -ginkgo.v
 
-build:
 # Precompile the test suite into a binary "_tests.test"
-	ginkgo build -race -r
+build:
+	${DEV_CMD} ginkgo build -race -r
+
+docker-build: build
+	docker build -t ${IMAGE} ${CURDIR}
+
+docker-push:
+	docker push ${IMAGE}
+
+# run tests inside of a container
+docker-test-integration:
+	docker run -e DEIS_WORKFLOW_SERVICE_HOST=${DEIS_WORKFLOW_SERVICE_HOST} ${IMAGE}

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,10 @@
+hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+updated: 2015-12-22T16:20:42.781138-08:00
+imports:
+- name: github.com/golang/protobuf
+  version: 68415e7123da32b07eab49c96d2c4d6158360e9b
+- name: github.com/onsi/ginkgo
+  version: e43390e35a4a88f3f95d5ddf9055efb7a1170469
+- name: github.com/onsi/gomega
+  version: 0fe204460da2c8fa1babcaac196e694de8f1aaa1
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,4 @@
+package: github.com/deis/workflow/_tests
+import:
+  - package: github.com/onsi/ginkgo
+  - package: github.com/onsi/gomega

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -102,7 +102,7 @@ var _ = BeforeEach(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	os.Chdir(testRoot)
-	output, err = execute(`git clone git@github.com:deis/example-go.git .`)
+	output, err = execute(`git clone https://github.com/deis/example-go.git`)
 	Expect(err).NotTo(HaveOccurred(), output)
 
 	login(url, testUser, testPassword)


### PR DESCRIPTION
Also add glide files for dependency management. With this patch, you can run `make docker-build docker-test-integration` to build and run the tests in a docker container.

Fixes #1 
Fixes deis/workflow#193
Fixes deis/workflow#139
Replaces deis/workflow#194

Note: we should make this public before merging, as it closes issues in deis/workflow, a public repository.