### PR TITLE
fix(deploy.sh): push docker images to deisci/ orgs

### DIFF
--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -5,7 +5,7 @@
 
 cd "$(dirname "$0")" || exit 1
 
-export IMAGE_PREFIX=deis VERSION=canary
+export IMAGE_PREFIX=deisci VERSION=canary
 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 DEIS_REGISTRY='' make -C .. docker-build docker-push
 docker login -e="$QUAY_EMAIL" -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io


### PR DESCRIPTION
Changes the repository org to `deisci` for consistency with the other images that are pushed for Deis v2.