### PR TITLE
fix(apps_test): update apps:info expectations

### DIFF
--- a/tests/apps_test.go
+++ b/tests/apps_test.go
@@ -145,9 +145,7 @@ var _ = Describe("Apps", func() {
 			sess, err := start("deis info -a %s", appName)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(sess).Should(Say("=== %s Processes", appName))
-			Eventually(sess).Should(SatisfyAny(
-				Say("web.1 initialized"),
-				Say("web.1 up")))
+			Eventually(sess).Should(Say(`%s-v\d-[\w-]+ up \(v\d\)`, appName))
 			Eventually(sess).Should(Say("=== %s Domains", appName))
 			Eventually(sess).Should(Exit(0))
 		})


### PR DESCRIPTION
This fixes a test that was broken by changes to deis/workflow. The current format is:
```console
$ deis info -a test-726978103
=== test-726978103 Application
updated:  2016-02-21T00:43:22UTC
uuid:     9cd804db-dc5a-47e4-ad3c-f0a23894d92b
created:  2016-02-21T00:43:09UTC
url:      test-726978103.192.168.64.2.xip.io:31560
owner:    test-81
id:       test-726978103

=== test-726978103 Processes
--- web:
test-726978103-v2-web-uriur up (v2)

=== test-726978103 Domains
test-726978103
```