### PR TITLE
fix(start): echo command line

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	neturl "net/url"
@@ -219,6 +220,7 @@ func start(cmdLine string, args ...interface{}) (*Session, error) {
 func startCmd(command Cmd) (*Session, error) {
 	cmd := exec.Command("/bin/sh", "-c", command.CommandLineString)
 	cmd.Env = command.Env
+	io.WriteString(GinkgoWriter, fmt.Sprintf("$ %s\n", command.CommandLineString))
 	return Start(cmd, GinkgoWriter, GinkgoWriter)
 }
 


### PR DESCRIPTION
Only the command stdeout/stderr was being printed, which was difficult to decipher without the relevant command. 
Before:
```console
Logged in as test-81
=== Apps
test-238696780
test-435805123
test-755573488
Destroying test-238696780...
done in 0s
```
After:
```console
$ deis login http://deis.192.168.64.2.xip.io:32762 --username=test-81 --password=asdf1234
Logged in as test-81
$ deis apps
=== Apps
test-238696780
test-435805123
test-755573488
$ deis destroy --app=test-238696780 --confirm=test-238696780
Destroying test-238696780...
done in 0s
```
Prints to `GinkoWriter` so everything will be silent unless a test case fails or the `-ginkgo.v` flag is given (which it is in `make test-integration`).