### PR TITLE
fix(ps_test): increase scale and restart timeouts to 5 min

### DIFF
--- a/tests/ps_test.go
+++ b/tests/ps_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Processes", func() {
 				sess, err := start("deis ps:scale web=%d --app=%s", scaleTo, testApp.Name)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(sess).Should(Say("Scaling processes... but first,"))
-				Eventually(sess, "2m").Should(Say(`done in \d+s`))
+				Eventually(sess, "5m").Should(Say(`done in \d+s`))
 				Eventually(sess).Should(Say("=== %s Processes", testApp.Name))
 				Eventually(sess).Should(Exit(0))
 
@@ -88,7 +88,7 @@ var _ = Describe("Processes", func() {
 				sess, err := start("deis ps:scale web=%d --app=%s", scaleTo, testApp.Name)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(sess).Should(Say("Scaling processes... but first,"))
-				Eventually(sess, "2m").Should(Say(`done in \d+s`))
+				Eventually(sess, "5m").Should(Say(`done in \d+s`))
 				Eventually(sess).Should(Say("=== %s Processes", testApp.Name))
 				Eventually(sess).Should(Exit(0))
 
@@ -115,7 +115,7 @@ var _ = Describe("Processes", func() {
 				if scaleTo == 0 || restart == "by wrong type" {
 					Eventually(sess).Should(Say("Could not find any processes to restart"))
 				} else {
-					Eventually(sess, "2m").Should(Say(`done in \d+s`))
+					Eventually(sess, "5m").Should(Say(`done in \d+s`))
 					Eventually(sess).Should(Say("=== %s Processes", testApp.Name))
 				}
 				Eventually(sess).Should(Exit(0))


### PR DESCRIPTION
The default of 2 minutes was sometimes not long enough for the `ps:scale` or `ps:restart` operation to complete. I've tested with a 5 minute timeout and not seen those failures recur.