### PR TITLE
feat(tests): add apps:transfer, apps:run

### DIFF
--- a/tests/keys_test.go
+++ b/tests/keys_test.go
@@ -3,8 +3,8 @@ package tests
 import (
 	"fmt"
 	"math/rand"
-	"time"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
apps:logs relies on https://github.com/sgoings/chart-mate/pull/2 so that is still blocked.