### PR TITLE
fix(tests/ps_test.go): fix Intn panic

### DIFF
--- a/tests/ps_test.go
+++ b/tests/ps_test.go
@@ -107,7 +107,9 @@ var _ = Describe("Processes", func() {
 					// TODO: need some way to choose between "web" and "cmd" here!
 					arg = "cmd"
 				case "one":
-					arg = beforeProcs[rand.Intn(len(beforeProcs))]
+					procsLen := len(beforeProcs)
+					Expect(procsLen).To(BeNumerically(">", 0))
+					arg = beforeProcs[rand.Intn(procsLen)]
 				}
 				sess, err = start("deis ps:restart %s --app=%s", arg, testApp.Name)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
some cases may cause the return value of scrapeProcs (the return value
of which is assigned to beforeProcs) to have no processes). This commit
ensures that there’s at least 1 returned process, or the test fails

Fixes #63 