### PR TITLE
fix(tests_suite): print commands again

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -246,9 +246,7 @@ func start(cmdLine string, args ...interface{}) (*Session, error) {
 func startCmd(command Cmd) (*Session, error) {
 	cmd := exec.Command("/bin/sh", "-c", command.CommandLineString)
 	cmd.Env = command.Env
-	if debug {
-		io.WriteString(GinkgoWriter, fmt.Sprintf("$ %s\n", command.CommandLineString))
-	}
+	io.WriteString(GinkgoWriter, fmt.Sprintf("$ %s\n", command.CommandLineString))
 	return Start(cmd, GinkgoWriter, GinkgoWriter)
 }
 


### PR DESCRIPTION
A debug check is not necessary, since the `GingkgoWriter` itself decides whether to print based on `go test` flags.