### PR TITLE
fix(Makefile): increase "slow test" warning to 2 min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ bootstrap:
 
 .PHONY: test-integration
 test-integration:
-	go test ./tests/... -v -ginkgo.v
+	go test ./tests/... -v -ginkgo.v -ginkgo.slowSpecThreshold=120
 
 # Precompile the test suite into a binary "_tests.test"
 .PHONY: build


### PR DESCRIPTION
Ginkgo's default of 5 seconds is unreasonable for e2e tests. The frequent warnings about "slow test" are not helpful in this context.

Closes #79.