### PR TITLE
fix(tests): enable the non-ascii config:set test

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -145,8 +145,7 @@ multiline string.`
 			Eventually(sess).Should(Exit(0))
 		})
 
-		XIt(`can set an environment variable with non-ASCII and multibyte chars
-Blocked until https://github.com/deis/workflow/issues/478 is fixed!`, func() {
+		It("can set an environment variable with non-ASCII and multibyte chars", func() {
 			sess, err := start("deis config:set FOO=讲台 BAR=Þorbjörnsson BAZ=ноль -a %s",
 				testApp.Name)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Now that deis/workflow#480 is merged, this test also passes:
```console
$ DEIS_ROUTER_SERVICE_HOST=192.168.64.2 DEIS_ROUTER_SERVICE_PORT=31759 make test-integration
...
$ deis run -a test-108788304 env
Running 'env'...
HOSTNAME=test-108788304-v3-run-1
KUBERNETES_PORT=tcp://10.100.0.1:443
KUBERNETES_PORT_443_TCP_PORT=443
FOO=讲台
KUBERNETES_SERVICE_PORT=443
KUBERNETES_SERVICE_HOST=10.100.0.1
TEST_108788304_PORT_80_TCP_PROTO=tcp
TEST_108788304_PORT_80_TCP_ADDR=10.100.228.98
TEST_108788304_SERVICE_PORT=80
DOCKERIMAGE=1
TEST_108788304_PORT=tcp://10.100.228.98:80
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/app/bin
TEST_108788304_SERVICE_HOST=10.100.228.98
PWD=/app
TEST_108788304_SERVICE_PORT_HTTP=80
GOMAXPROCS=1
HOME=/app
SHLVL=1
KUBERNETES_PORT_443_TCP_PROTO=tcp
BAR=Þorbjörnsson
TEST_108788304_PORT_80_TCP_PORT=80
PORT=5000
KUBERNETES_PORT_443_TCP_ADDR=10.100.0.1
TEST_108788304_PORT_80_TCP=tcp://10.100.228.98:80
KUBERNETES_PORT_443_TCP=tcp://10.100.0.1:443
BAZ=ноль
DEIS_RELEASE=2.0.0-dev
_=/usr/bin/env
...
$ deis auth:cancel --username=admin --password=admin --yes
Please log in again in order to cancel this account
Logged in as admin
Account cancelled

Ran 1 of 92 Specs in 70.751 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 91 Skipped PASS | FOCUSED
```