### PR TITLE
fix(Makefile): increase overall test timeout to 60 min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ bootstrap:
 
 .PHONY: test-integration
 test-integration:
-	go test ./tests/... -v -ginkgo.v -ginkgo.slowSpecThreshold=120
+	go test ./tests/... -v -timeout 60m -ginkgo.v -ginkgo.slowSpecThreshold=120
 
 # Precompile the test suite into a binary "_tests.test"
 .PHONY: build


### PR DESCRIPTION
Now that the e2e tests are more fleshed out, they routinely take longer than `go test`'s default of 10 minutes.

cc:@vdice