### PR TITLE
fix(destroyApp): allow max timeout for "deis destroy"

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -349,7 +349,7 @@ func createApp(name string, options ...string) *Session {
 func destroyApp(app App) *Session {
 	cmd, err := start("deis apps:destroy --app=%s --confirm=%s", app.Name, app.Name)
 	Expect(err).NotTo(HaveOccurred())
-	Eventually(cmd).Should(Exit(0))
+	Eventually(cmd, defaultMaxTimeout).Should(Exit(0))
 	Eventually(cmd).Should(SatisfyAll(
 		Say("Destroying %s...", app.Name),
 		Say(`done in `)))


### PR DESCRIPTION
In CI we have seen at least [one case](https://ci.deis.io/job/deis-v2-e2e/962/console) where the default `Eventually` timeout of 10 seconds was not enough for a `deis destroy` operation, which isn't surprising. This bumps that up to `defaultMaxTimeout` (5 minutes).