### PR TITLE
bug(tests): wait for router to reload before testing config change

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"sync"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -30,6 +31,8 @@ var _ = Describe("Config", func() {
 		})
 
 		It("can set and list environment variables", func() {
+			time.Sleep(10 * time.Second) // wait for router to reload
+
 			sess, err := start("deis config:set POWERED_BY=midi-chlorians")
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(sess).Should(Say("Creating config"))


### PR DESCRIPTION
Test: "can set and list environment variables"
Jenkins job: https://ci.deis.io/job/workflow-beta1-test-e2e/17/

It looks like we are hitting the app before the router has had a chance to reload, causing a 404:
```
00:15:33.957   can set and list environment variables
00:15:33.958   /go/src/github.com/deis/workflow-e2e/tests/config_test.go:55
00:15:35.220 $ deis login http://deis.10.187.248.89.xip.io --username=test-81 --password=asdf1234
00:15:35.273 Logged in as test-81
00:15:35.278 $ deis apps:create test-23966460 
00:15:35.464 Creating Application... ...done, created test-23966460
00:15:35.468 Git remote deis added
00:15:35.468 remote available at ssh://git@deis.10.187.248.89.xip.io:2222/test-23966460.git
00:15:35.478 $ GIT_SSH=/tmp/deis-workflow-home943620212/.ssh/git-ssh git push deis master

[REMOVED]
     
00:15:46.424 remote: running [git gc] in directory /home/git/test-23966460.git        
00:15:46.430 To ssh://git@deis.10.187.248.89.xip.io:2222/test-23966460.git
00:15:46.430  * [new branch]      master -> master
00:15:46.430 $ deis config:set POWERED_BY=midi-chlorians
00:15:49.709 Creating config... ...o...o...o...o...o...o...done
00:15:49.709 
00:15:49.745 === test-23966460 Config
00:15:49.745 POWERED_BY      midi-chlorians
00:15:49.761 $ deis config:list -a test-23966460
00:15:49.793 === test-23966460 Config
00:15:49.793 POWERED_BY      midi-chlorians
00:15:49.803 $ curl -sL "http://test-23966460.10.187.248.89.xip.io"; echo
00:15:49.874 <html>
00:15:49.874 <head><title>404 Not Found</title></head>
00:15:49.875 <body bgcolor="white">
00:15:49.875 <center><h1>404 Not Found</h1></center>
00:15:49.875 <hr><center>nginx/1.9.6</center>
00:15:49.875 </body>
00:15:49.875 </html>
00:15:49.875 
```

Looking at the router logs, there is a reload, but we immediately see the 404 later in the logs:
```
[22/Mar/2016:04:35:09 +0000] - 10.184.0.9 - - - 201 - "POST /v2/apps/ HTTP/1.1" - 522 - "-" - "Deis Client v2.0.0-dev" - "~^deis\x5C.(?<domain>.+)$" - 10.187.244.132:80 - deis.10.187.248.89.xip.io - 0.175 - 0.175
2016/03/22 04:35:16 WARNING: Field "router.deis.io/certificates" value "" does not satisfy constraint /(?i)^((([a-z0-9]+(-[a-z0-9]+)*)|((\*\.)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}):([a-z0-9]+(-[a-z0-9]+)*)(\s*,\s*)?)+$/ -- skipping this field and using default value "map[]".
2016/03/22 04:35:16 INFO: Router configuration has changed in k8s.
2016/03/22 04:35:16 INFO: Reloading nginx...
2016/03/22 04:35:16 INFO: nginx reloaded.
[22/Mar/2016:04:35:23 +0000] - 10.184.0.9 - - - 201 - "POST /v2/apps/test-23966460/config/ HTTP/1.1" - 597 - "-" - "Deis Client v2.0.0-dev" - "~^deis\x5C.(?<domain>.+)$" - 10.187.244.132:80 - deis.10.187.248.89.xip.io - 3.261 - 3.261
[22/Mar/2016:04:35:23 +0000] - 10.184.0.9 - - - 200 - "GET /v2/apps/test-23966460/config/ HTTP/1.1" - 585 - "-" - "Deis Client v2.0.0-dev" - "~^deis\x5C.(?<domain>.+)$" - 10.187.244.132:80 - deis.10.187.248.89.xip.io - 0.033 - 0.034
[22/Mar/2016:04:35:23 +0000] - 10.184.0.9 - - - 200 - "GET /v2/apps/test-23966460/config/ HTTP/1.1" - 595 - "-" - "Deis Client v2.0.0-dev" - "~^deis\x5C.(?<domain>.+)$" - 10.187.244.132:80 - deis.10.187.248.89.xip.io - 0.022 - 0.023
[22/Mar/2016:04:35:23 +0000] - 10.184.0.9 - - - 404 - "GET / HTTP/1.1" - 322 - "-" - "curl/7.35.0" - "_" - - - test-23966460.10.187.248.89.xip.io - - - 0.000
```

There are further router reloads at (but it is difficult to tell what the router knows about at any given moment):
```
2016/03/22 04:37:06 INFO: Router configuration has changed in k8s.
2016/03/22 04:39:46 INFO: Router configuration has changed in k8s.
2016/03/22 04:39:56 INFO: Router configuration has changed in k8s.
2016/03/22 04:40:26 INFO: Router configuration has changed in k8s.
```