### PR TITLE
feature: Run the e2e test suite in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
 install:
 - make bootstrap
 script:
-- make build docker-build
+- make docker-build
 deploy:
 - provider: script
   script: _scripts/deploy.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
-FROM ubuntu-debootstrap:14.04
+FROM quay.io/deis/go-dev:0.9.0
 
-ENV DOCKERIMAGE=1
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl wget openssh-client git g++ gcc libc6-dev make bzr git mercurial openssh-client subversion procps && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update -y && apt-get install -y curl openssh-client git
-RUN curl -sSL http://deis.io/deis-cli/install-v2-alpha.sh | bash && mv ./deis /bin/deis
-COPY tests/tests.test .
-RUN mv tests.test /bin
-RUN mkdir /files
-COPY tests/files /files
-CMD /bin/tests.test
+#Install deis cli
+RUN wget https://dl.bintray.com/deis/deisci/deis-6c176d2-linux-amd64 && \
+    mv ./deis-6c176d2-linux-amd64 /bin/deis && \
+    chmod +x /bin/deis
+
+# Install the kubectl cli
+RUN curl -O https://storage.googleapis.com/kubernetes-release/release/v1.1.8/bin/linux/amd64/kubectl && \
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin/kubectl
+
+COPY . /go/src/github.com/deis/workflow-e2e
+WORKDIR /go/src/github.com/deis/workflow-e2e

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ bootstrap:
 
 .PHONY: test-integration
 test-integration:
-	go test ./tests/... ${TEST_OPTS}
+	ginkgo tests/ -p -slowSpecThreshold=120.00 -succinct -progress
 
 # Precompile the test suite into a binary "_tests.test"
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ DEV_IMG := quay.io/deis/go-dev:0.9.0
 RUN_CMD := docker run --rm -e DEIS_ROUTER_SERVICE_HOST=${DEIS_ROUTER_SERVICE_HOST} -e DEIS_ROUTER_SERVICE_PORT=${DEIS_ROUTER_SERVICE_PORT} -v ${CURDIR}:${SRC_PATH} -w ${SRC_PATH} ${DEV_IMG}
 DEV_CMD := docker run --rm -e GO15VENDOREXPERIMENT=1 -v ${CURDIR}:${SRC_PATH} -w ${SRC_PATH} ${DEV_IMG}
 
-TEST_OPTS := -test.v -test.timeout=60m -ginkgo.v -ginkgo.slowSpecThreshold=120
+TEST_OPTS := -slowSpecThreshold=120.00 -noisyPendings=false
+PARALLEL_TEST_OPTS := ${TEST_OPTS} -p
 
 MUTABLE_VERSION ?= canary
 VERSION ?= git-$(shell git rev-parse --short HEAD)
@@ -24,15 +25,14 @@ bootstrap:
 
 .PHONY: test-integration
 test-integration:
-	ginkgo tests/ -p -slowSpecThreshold=120.00 -succinct -progress
+	DEFAULT_EVENTUALLY_TIMEOUT="30s" ginkgo $TEST_OPTS tests/
 
-# Precompile the test suite into a binary "_tests.test"
-.PHONY: build
-build:
-	${DEV_CMD} ginkgo build -race -r
+.PHONY: test-integration
+test-integration-parallel:
+	ginkgo $PARALLEL_TEST_OPTS tests/
 
 .PHONY: docker-build
-docker-build: build
+docker-build:
 	docker build -t ${IMAGE} ${CURDIR}
 	docker tag -f ${IMAGE} ${MUTABLE_IMAGE}
 
@@ -51,5 +51,13 @@ docker-mutable-push:
 # run tests inside of a container
 docker-test-integration:
 	docker run -e DEIS_ROUTER_SERVICE_HOST=${DEIS_ROUTER_SERVICE_HOST} \
-	  -e DEIS_ROUTER_SERVICE_PORT=${DEIS_ROUTER_SERVICE_PORT} ${IMAGE} \
-	  /bin/tests.test ${TEST_OPTS}
+	  				 -e DEIS_ROUTER_SERVICE_PORT=${DEIS_ROUTER_SERVICE_PORT} \
+						 -e TEST_OPTS=${TEST_OPTS}
+						 -e DEFAULT_EVENTUALLY_TIMEOUT="30s" ${IMAGE}
+
+.PHONY: docker-test-integration-parallel
+# run tests inside of a container
+docker-test-integration-parallel:
+	docker run -e DEIS_ROUTER_SERVICE_HOST=${DEIS_ROUTER_SERVICE_HOST} \
+	  				 -e DEIS_ROUTER_SERVICE_PORT=${DEIS_ROUTER_SERVICE_PORT} \
+						 -e TEST_OPTS=${PARALLEL_TEST_OPTS} ${IMAGE}

--- a/tests/admin_test.go
+++ b/tests/admin_test.go
@@ -1,0 +1,96 @@
+package tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Admin", func() {
+	Context("when logged in as an admin user", func() {
+		var testData TestData
+		var testApp App
+
+		BeforeEach(func() {
+			testData = initTestData()
+			testApp.Name = getRandAppName()
+			gitInit()
+			createApp(testData.Profile, testApp.Name)
+		})
+
+		It("can create, list, and delete admin permissions", func() {
+			sess, err := start("deis perms:create %s --admin", adminTestData.Profile, testData.Username)
+			Eventually(sess, defaultMaxTimeout).Should(Say("Adding %s to system administrators... done\n", testData.Username))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
+			sess, err = start("deis perms:list --admin", adminTestData.Profile)
+			Eventually(sess).Should(Say("=== Administrators"))
+			Eventually(sess).Should(Say(adminTestData.Username))
+			Eventually(sess).Should(Say(testData.Username))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
+			sess, err = start("deis perms:delete %s --admin", adminTestData.Profile, testData.Username)
+			Eventually(sess, defaultMaxTimeout).Should(Say("Removing %s from system administrators... done", testData.Username))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
+			sess, err = start("deis perms:list --admin", adminTestData.Profile)
+			Eventually(sess).Should(Say("=== Administrators"))
+			Expect(sess).ShouldNot(Say(testData.Username))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("can create, list, and delete app permissions", func() {
+			sess, err := start("deis perms:create %s --app=%s", adminTestData.Profile, testData.Username, testApp.Name)
+			Eventually(sess, defaultMaxTimeout).Should(Say("Adding %s to %s collaborators... done\n", testData.Username, testApp.Name))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
+			sess, err = start("deis perms:list --app=%s", adminTestData.Profile, testApp.Name)
+			Eventually(sess).Should(Say("=== %s's Users", testApp.Name))
+			Eventually(sess).Should(Say("%s", testData.Username))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
+			sess, err = start("deis perms:delete %s --app=%s", adminTestData.Profile, testData.Username, testApp.Name)
+			Eventually(sess, defaultMaxTimeout).Should(Say("Removing %s from %s collaborators... done", testData.Username, testApp.Name))
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
+			sess, err = start("deis perms:list --app=%s", adminTestData.Profile, testApp.Name)
+			Eventually(sess).Should(Say("=== %s's Users", testApp.Name))
+			Eventually(sess).ShouldNot(Say("%s", testData.Username))
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("regenerates the token for a specified user", func() {
+			sess, err := start("deis auth:regenerate -u %s", adminTestData.Profile, testData.Username)
+			Eventually(sess).Should(Say("Token Regenerated"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		// This is marked pending because it resets all user auth tokens. Because we run the tests in parallel
+		// this can wreak havoc on tests that may be in flight. We will need to reevaluate how we want to test this functionality.
+		XIt("regenerates the token for all users", func() {
+			sess, err := start("deis auth:regenerate --all", adminTestData.Profile)
+			Eventually(sess).Should(Say("Token Regenerated"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("can list all users", func() {
+			sess, err := start("deis users:list", adminTestData.Profile)
+			Eventually(sess).Should(Say("=== Users"))
+			output := string(sess.Out.Contents())
+			Expect(output).To(ContainSubstring(adminTestData.Username))
+			Expect(output).To(ContainSubstring(testData.Username))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+})

--- a/tests/apps_test.go
+++ b/tests/apps_test.go
@@ -21,6 +21,7 @@ var _ = Describe("Apps", func() {
 	var testApp App
 
 	BeforeEach(func() {
+		url, testUser, testPassword, testEmail, keyName = createRandomUser()
 		testApp.Name = getRandAppName()
 	})
 
@@ -57,19 +58,11 @@ var _ = Describe("Apps", func() {
 	})
 
 	Context("when creating an app", func() {
-		var cleanup bool
 
 		BeforeEach(func() {
-			cleanup = true
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
 			testApp.Name = getRandAppName()
 			gitInit()
-		})
-
-		AfterEach(func() {
-			if cleanup {
-				destroyApp(testApp)
-				gitClean()
-			}
 		})
 
 		It("creates an app with a git remote", func() {
@@ -87,10 +80,6 @@ var _ = Describe("Apps", func() {
 				Say("created %s", testApp.Name),
 				Say("remote available at ")))
 			Eventually(cmd).ShouldNot(Say("Git remote deis added"))
-
-			cleanup = false
-			cmd = destroyApp(testApp)
-			Eventually(cmd).ShouldNot(Say("Git remote deis removed"))
 		})
 
 		It("creates an app with a custom buildpack", func() {
@@ -109,11 +98,10 @@ var _ = Describe("Apps", func() {
 	})
 
 	Context("with a deployed app", func() {
-		var cleanup bool
 		var testApp App
 
 		BeforeEach(func() {
-			cleanup = true
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
 			os.Chdir("example-go")
 			appName := getRandAppName()
 			createApp(appName)
@@ -122,9 +110,6 @@ var _ = Describe("Apps", func() {
 
 		AfterEach(func() {
 			defer os.Chdir("..")
-			if cleanup {
-				destroyApp(testApp)
-			}
 		})
 
 		It("can't create an existing app", func() {
@@ -164,32 +149,18 @@ var _ = Describe("Apps", func() {
 			sess, _ := start("deis info -a %s", testApp.Name)
 			Eventually(sess).Should(Exit(1))
 			Eventually(sess.Err).Should(Say("You do not have permission to perform this action."))
-			// destroy it ourselves because the spec teardown cannot destroy as regular user
-			cleanup = false
-			login(url, testAdminUser, testAdminPassword)
-			destroyApp(testApp)
-			// log back in and continue with the show
-			login(url, testUser, testPassword)
 		})
 	})
 
 	Context("with a custom buildpack deployed app", func() {
-		var cleanup bool
 		var testApp App
 
 		BeforeEach(func() {
-			cleanup = true
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
 			os.Chdir("example-perl")
 			appName := getRandAppName()
 			createApp(appName, "--buildpack", "https://github.com/miyagawa/heroku-buildpack-perl.git")
 			testApp = deployApp(appName)
-		})
-
-		AfterEach(func() {
-			defer os.Chdir("..")
-			if cleanup {
-				destroyApp(testApp)
-			}
 		})
 
 		It("can get app info", func() {

--- a/tests/apps_test.go
+++ b/tests/apps_test.go
@@ -18,94 +18,100 @@ import (
 var uuidRegExp = `[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}`
 
 var _ = Describe("Apps", func() {
-	var testApp App
-
-	BeforeEach(func() {
-		url, testUser, testPassword, testEmail, keyName = createRandomUser()
-		testApp.Name = getRandAppName()
-	})
 
 	Context("with no app", func() {
+		var testApp App
+		var testData TestData
+
+		BeforeEach(func() {
+			testApp.Name = getRandAppName()
+			testData = initTestData()
+		})
 
 		It("can't get app info", func() {
-			sess, _ := start("deis info -a %s", testApp.Name)
-			Eventually(sess).Should(Exit(1))
+			sess, err := start("deis info -a %s", testData.Profile, testApp.Name)
 			Eventually(sess.Err).Should(Say("Not found."))
+			Eventually(sess).Should(Exit(1))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("can't get app logs", func() {
-			sess, err := start("deis logs -a %s", testApp.Name)
-			Expect(err).To(BeNil())
-			Eventually(sess).Should(Exit(1))
+			sess, err := start("deis logs -a %s", testData.Profile, testApp.Name)
 			Eventually(sess.Err).Should(Say(`Error: There are currently no log messages. Please check the following things:`))
+			Eventually(sess).Should(Exit(1))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("can't run a command in the app environment", func() {
-			sess, err := start("deis apps:run echo Hello, 世界")
-			Expect(err).To(BeNil())
+			sess, err := start("deis apps:run echo Hello, 世界", testData.Profile)
 			Eventually(sess).Should(Say("Running 'echo Hello, 世界'..."))
 			Eventually(sess.Err).Should(Say("Not found."))
 			Eventually(sess).ShouldNot(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("can't open a bogus app URL", func() {
-			sess, err := start("deis open -a %s", getRandAppName())
-			Expect(err).To(BeNil())
-			Eventually(sess).Should(Exit(1))
+			sess, err := start("deis open -a %s", testData.Profile, getRandAppName())
 			Eventually(sess.Err).Should(Say("404 Not Found"))
+			Eventually(sess).Should(Exit(1))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 	})
 
 	Context("when creating an app", func() {
+		var testApp App
+		var testData TestData
 
 		BeforeEach(func() {
-			url, testUser, testPassword, testEmail, keyName = createRandomUser()
+			testData = initTestData()
 			testApp.Name = getRandAppName()
 			gitInit()
 		})
 
 		It("creates an app with a git remote", func() {
-			cmd, err := start("deis apps:create %s", testApp.Name)
+			sess, err := start("deis apps:create %s", testData.Profile, testApp.Name)
+			Eventually(sess, defaultMaxTimeout).Should(Say("created %s", testApp.Name))
+			Eventually(sess).Should(Say(`Git remote deis added`))
+			Eventually(sess).Should(Say(`remote available at `))
+			Eventually(sess).Should(Exit(0))
 			Expect(err).NotTo(HaveOccurred())
-			Eventually(cmd).Should(Say("created %s", testApp.Name))
-			Eventually(cmd).Should(Say(`Git remote deis added`))
-			Eventually(cmd).Should(Say(`remote available at `))
 		})
 
 		It("creates an app with no git remote", func() {
-			cmd, err := start("deis apps:create %s --no-remote", testApp.Name)
+			sess, err := start("deis apps:create %s --no-remote", testData.Profile, testApp.Name)
+			Eventually(sess, defaultMaxTimeout).Should(Say("created %s", testApp.Name))
+			Eventually(sess).Should(Say("remote available at "))
+			Eventually(sess).ShouldNot(Say("Git remote deis added"))
+			Eventually(sess).Should(Exit(0))
 			Expect(err).NotTo(HaveOccurred())
-			Eventually(cmd).Should(SatisfyAll(
-				Say("created %s", testApp.Name),
-				Say("remote available at ")))
-			Eventually(cmd).ShouldNot(Say("Git remote deis added"))
 		})
 
 		It("creates an app with a custom buildpack", func() {
-			sess, err := start("deis apps:create %s --buildpack https://example.com", testApp.Name)
-			Expect(err).To(BeNil())
-			Eventually(sess).Should(Exit(0))
-			Eventually(sess).Should(Say("created %s", testApp.Name))
+			sess, err := start("deis apps:create %s --buildpack https://example.com", testData.Profile, testApp.Name)
+			Eventually(sess, defaultMaxTimeout).Should(Say("created %s", testApp.Name))
 			Eventually(sess).Should(Say("Git remote deis added"))
 			Eventually(sess).Should(Say("remote available at "))
-
-			sess, err = start("deis config:list -a %s", testApp.Name)
-			Expect(err).To(BeNil())
 			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
+
+			sess, err = start("deis config:list -a %s", testData.Profile, testApp.Name)
 			Eventually(sess).Should(Say("BUILDPACK_URL"))
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
 	Context("with a deployed app", func() {
 		var testApp App
+		var testData TestData
 
 		BeforeEach(func() {
-			url, testUser, testPassword, testEmail, keyName = createRandomUser()
+			testData = initTestData()
 			os.Chdir("example-go")
 			appName := getRandAppName()
-			createApp(appName)
-			testApp = deployApp(appName)
+			createApp(testData.Profile, appName)
+			testApp = deployApp(testData.Profile, appName)
 		})
 
 		AfterEach(func() {
@@ -113,85 +119,87 @@ var _ = Describe("Apps", func() {
 		})
 
 		It("can't create an existing app", func() {
-			sess, err := start("deis apps:create %s", testApp.Name)
-			Expect(err).NotTo(HaveOccurred())
+			sess, err := start("deis apps:create %s", testData.Profile, testApp.Name)
 			Eventually(sess.Err).Should(Say("App with this id already exists."))
 			Eventually(sess).ShouldNot(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("can get app info", func() {
-			verifyAppInfo(testApp)
+			verifyAppInfo(testData.Profile, testData.Username, testApp.Name, testApp.URL)
 		})
 
 		// V broken
 		XIt("can get app logs", func() {
-			cmd, err := start("deis logs")
+			sess, err := start("deis logs", testData.Profile)
+			Eventually(sess).Should(SatisfyAll(
+				Say("%s\\[deis-controller\\]\\: %s created initial release", testApp.Name, testData.Username),
+				Say("%s\\[deis-controller\\]\\: %s deployed", testApp.Name, testData.Username),
+				Say("%s\\[deis-controller\\]\\: %s scaled containers", testApp.Name, testData.Username)))
+			Eventually(sess).Should(Exit(0))
 			Expect(err).NotTo(HaveOccurred())
-			Eventually(cmd).Should(SatisfyAll(
-				Say("%s\\[deis-controller\\]\\: %s created initial release", testApp.Name, testUser),
-				Say("%s\\[deis-controller\\]\\: %s deployed", testApp.Name, testUser),
-				Say("%s\\[deis-controller\\]\\: %s scaled containers", testApp.Name, testUser)))
 		})
 
 		It("can open the app's URL", func() {
-			verifyAppOpen(testApp)
+			verifyAppOpen(testData.Profile, testApp.URL)
 		})
 
 		It("can run a command in the app environment", func() {
-			sess, err := start("deis apps:run echo Hello, 世界")
-			Expect(err).NotTo(HaveOccurred())
+			sess, err := start("deis apps:run echo Hello, 世界", testData.Profile)
 			Eventually(sess, (1 * time.Minute)).Should(Say("Hello, 世界"))
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("can transfer the app to another owner", func() {
-			_, err := start("deis apps:transfer " + testAdminUser)
+			sess, err := start("deis apps:transfer %s", testData.Profile, adminTestData.Username)
 			Expect(err).NotTo(HaveOccurred())
-			sess, _ := start("deis info -a %s", testApp.Name)
-			Eventually(sess).Should(Exit(1))
+			Eventually(sess).Should(Exit(0))
+			sess, err = start("deis info -a %s", testData.Profile, testApp.Name)
 			Eventually(sess.Err).Should(Say("You do not have permission to perform this action."))
+			Eventually(sess).Should(Exit(1))
 		})
 	})
 
 	Context("with a custom buildpack deployed app", func() {
 		var testApp App
+		var testData TestData
 
 		BeforeEach(func() {
-			url, testUser, testPassword, testEmail, keyName = createRandomUser()
+			testData = initTestData()
 			os.Chdir("example-perl")
 			appName := getRandAppName()
-			createApp(appName, "--buildpack", "https://github.com/miyagawa/heroku-buildpack-perl.git")
-			testApp = deployApp(appName)
+			createApp(testData.Profile, appName, "--buildpack", "https://github.com/miyagawa/heroku-buildpack-perl.git")
+			testApp = deployApp(testData.Profile, appName)
 		})
 
 		It("can get app info", func() {
-			verifyAppInfo(testApp)
+			verifyAppInfo(testData.Profile, testData.Username, testApp.Name, testApp.URL)
 		})
 
 		It("can open the app's URL", func() {
-			verifyAppOpen(testApp)
+			verifyAppOpen(testData.Profile, testApp.URL)
 		})
 
 	})
 })
 
-func verifyAppInfo(testApp App) {
-	sess, err := start("deis info -a %s", testApp.Name)
-	Expect(err).NotTo(HaveOccurred())
-	Eventually(sess).Should(Say("=== %s Application", testApp.Name))
+func verifyAppInfo(profile string, username string, appName string, url string) {
+	sess, err := start("deis info -a %s", profile, appName)
+	Eventually(sess).Should(Say("=== %s Application", appName))
 	Eventually(sess).Should(Say(`uuid:\s*%s`, uuidRegExp))
-	Eventually(sess).Should(Say(`url:\s*%s`, strings.Replace(testApp.URL, "http://", "", 1)))
-	Eventually(sess).Should(Say(`owner:\s*%s`, testUser))
-	Eventually(sess).Should(Say(`id:\s*%s`, testApp.Name))
-
-	Eventually(sess).Should(Say("=== %s Processes", testApp.Name))
-	Eventually(sess).Should(Say(procsRegexp, testApp.Name))
-
-	Eventually(sess).Should(Say("=== %s Domains", testApp.Name))
-	Eventually(sess).Should(Say("%s", testApp.Name))
+	Eventually(sess).Should(Say(`url:\s*%s`, strings.Replace(url, "http://", "", 1)))
+	Eventually(sess).Should(Say(`owner:\s*%s`, username))
+	Eventually(sess).Should(Say(`id:\s*%s`, appName))
+	Eventually(sess).Should(Say("=== %s Processes", appName))
+	Eventually(sess).Should(Say(procsRegexp, appName))
+	Eventually(sess).Should(Say("=== %s Domains", appName))
+	Eventually(sess).Should(Say("%s", appName))
 	Eventually(sess).Should(Exit(0))
+	Expect(err).NotTo(HaveOccurred())
 }
 
-func verifyAppOpen(testApp App) {
+func verifyAppOpen(profile string, url string) {
 	// the underlying open utility 'deis open' looks for
 	toShim := "open" //darwin
 	if runtime.GOOS == "linux" {
@@ -207,12 +215,13 @@ func verifyAppOpen(testApp App) {
 	env := shims.PrependPath(os.Environ(), os.TempDir())
 
 	// invoke functionality under test
-	sess, err := startCmd(Cmd{Env: env, CommandLineString: "deis open"})
+	sess, err := startCmd(Cmd{Env: env, CommandLineString: "DEIS_PROFILE=" + profile + " deis open"})
 	Expect(err).To(BeNil())
 	Eventually(sess).Should(Exit(0))
+	Expect(err).NotTo(HaveOccurred())
 
 	// check shim output
 	output, err := ioutil.ReadFile(myShim.OutFile.Name())
 	Expect(err).NotTo(HaveOccurred())
-	Expect(strings.TrimSpace(string(output))).To(Equal(testApp.URL))
+	Expect(strings.TrimSpace(string(output))).To(Equal(url))
 }

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -22,6 +22,10 @@ var _ = Describe("Auth", func() {
 	})
 
 	Context("when logged in", func() {
+		BeforeEach(func() {
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
+		})
+
 		It("can log out", func() {
 			logout()
 		})
@@ -50,6 +54,7 @@ var _ = Describe("Auth", func() {
 
 	Context("when logged in as an admin", func() {
 		BeforeEach(func() {
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
 			login(url, testAdminUser, testAdminPassword)
 		})
 

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -14,16 +14,17 @@ var _ = Describe("Auth", func() {
 		})
 
 		It("won't print the current user", func() {
-			sess, err := start("deis auth:whoami")
-			Expect(err).To(BeNil())
-			Eventually(sess).Should(Exit(1))
+			sess, err := start("deis auth:whoami", "")
 			Eventually(sess.Err).Should(Say("Not logged in"))
+			Eventually(sess).Should(Exit(1))
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
 	Context("when logged in", func() {
+		var testData TestData
 		BeforeEach(func() {
-			url, testUser, testPassword, testEmail, keyName = createRandomUser()
+			testData = initTestData()
 		})
 
 		It("can log out", func() {
@@ -32,42 +33,24 @@ var _ = Describe("Auth", func() {
 
 		It("won't register twice", func() {
 			cmd := "deis register %s --username=%s --password=%s --email=%s"
-			out, err := execute(cmd, url, testUser, testPassword, testEmail)
-			Expect(err).To(HaveOccurred())
-			Expect(out).To(ContainSubstring("Registration failed"))
+			sess, err := start(cmd, testData.Profile, testData.ControllerURL, testData.Username, testData.Password, testData.Email)
+			Eventually(sess.Err).Should(Say("Registration failed"))
+			Eventually(sess).Should(Exit(1))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("prints the current user", func() {
-			sess, err := start("deis auth:whoami")
-			Expect(err).To(BeNil())
+			sess, err := start("deis auth:whoami", testData.Profile)
+			Eventually(sess).Should(Say("You are %s", testData.Username))
 			Eventually(sess).Should(Exit(0))
-			Eventually(sess).Should(Say("You are %s", testUser))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("regenerates the token for the current user", func() {
-			sess, err := start("deis auth:regenerate")
-			Expect(err).To(BeNil())
-			Eventually(sess).Should(Exit(0))
+			sess, err := start("deis auth:regenerate", testData.Profile)
 			Eventually(sess).Should(Say("Token Regenerated"))
-		})
-	})
-
-	Context("when logged in as an admin", func() {
-		BeforeEach(func() {
-			url, testUser, testPassword, testEmail, keyName = createRandomUser()
-			login(url, testAdminUser, testAdminPassword)
-		})
-
-		It("regenerates the token for a specified user", func() {
-			output, err := execute("deis auth:regenerate -u %s", testUser)
+			Eventually(sess).Should(Exit(0))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("Token Regenerated"))
-		})
-
-		It("regenerates the token for all users", func() {
-			output, err := execute("deis auth:regenerate --all")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring("Token Regenerated"))
 		})
 	})
 })

--- a/tests/builds_test.go
+++ b/tests/builds_test.go
@@ -15,23 +15,23 @@ import (
 // createBuild invokes deis builds:create <image> -a <app>
 // with provided <image> on provided <app>
 // and validates that no errors have occurred and build was successful
-func createBuild(image string, app App, options ...string) {
-	pullOrCreateBuild(image, app, "builds:create", strings.Join(options, " "))
+func createBuild(profile string, image string, app App, options ...string) {
+	pullOrCreateBuild(profile, image, app, "builds:create", strings.Join(options, " "))
 }
 
 // deisPull invokes deis pull <image> -a <app>
 // with provided <image> on provided <app>
 // and validates that no errors have occurred and build was successful
-func deisPull(image string, app App, options ...string) {
-	pullOrCreateBuild(image, app, "pull", strings.Join(options, " "))
+func deisPull(profile string, image string, app App, options ...string) {
+	pullOrCreateBuild(profile, image, app, "pull", strings.Join(options, " "))
 }
 
-func pullOrCreateBuild(image string, app App, command string, options string) {
-	sess, err := start("deis %s %s -a %s %s", command, image, app.Name, options)
-	Expect(err).To(BeNil())
-	Eventually(sess, defaultMaxTimeout).Should(Exit(0))
+func pullOrCreateBuild(profile string, image string, app App, command string, options string) {
+	sess, err := start("deis %s %s -a %s %s", profile, command, image, app.Name, options)
 	Eventually(sess).Should(Say("Creating build..."))
-	Eventually(sess).Should(Say("done"))
+	Eventually(sess, defaultMaxTimeout).Should(Say("done"))
+	Eventually(sess).Should(Exit(0))
+	Expect(err).NotTo(HaveOccurred())
 }
 
 var _ = Describe("Builds", func() {
@@ -39,9 +39,10 @@ var _ = Describe("Builds", func() {
 		var exampleRepo string
 		var exampleImage string
 		var testApp App
+		var testData TestData
 
 		BeforeEach(func() {
-			url, testUser, testPassword, testEmail, keyName = createRandomUser()
+			testData = initTestData()
 			exampleRepo = "example-go"
 			exampleImage = fmt.Sprintf("deis/%s:latest", exampleRepo)
 			testApp.Name = getRandAppName()
@@ -54,26 +55,27 @@ var _ = Describe("Builds", func() {
 
 		Context("with no app", func() {
 			It("cannot create a build without existing app", func() {
-				cmd, err := start("deis builds:create %s -a %s", exampleImage, testApp.Name)
+				sess, err := start("deis builds:create %s -a %s", testData.Profile, exampleImage, testApp.Name)
+				Eventually(sess.Err).Should(Say("404 Not Found"))
+				Eventually(sess).Should(Exit(1))
 				Expect(err).NotTo(HaveOccurred())
-				Eventually(cmd.Err).Should(Say("404 Not Found"))
-				Eventually(cmd).Should(Exit(1))
 			})
 		})
 
 		Context("with existing app", func() {
+			var testData TestData
 
 			BeforeEach(func() {
-				url, testUser, testPassword, testEmail, keyName = createRandomUser()
-				createApp(testApp.Name)
-				createBuild(exampleImage, testApp)
+				testData = initTestData()
+				createApp(testData.Profile, testApp.Name)
+				createBuild(testData.Profile, exampleImage, testApp)
 			})
 
 			It("can list app builds", func() {
-				cmd, err := start("deis builds:list -a %s", testApp.Name)
+				sess, err := start("deis builds:list -a %s", testData.Profile, testApp.Name)
+				Eventually(sess).Should(Say(uuidRegExp))
+				Eventually(sess).Should(Exit(0))
 				Expect(err).NotTo(HaveOccurred())
-				Eventually(cmd).Should(Exit(0))
-				Eventually(cmd).Should(Say(uuidRegExp))
 			})
 		})
 
@@ -81,25 +83,26 @@ var _ = Describe("Builds", func() {
 			var curlCmd Cmd
 			var cmdRetryTimeout int
 			var procFile string
+			var testData TestData
 
 			BeforeEach(func() {
-				url, testUser, testPassword, testEmail, keyName = createRandomUser()
+				testData = initTestData()
 				cmdRetryTimeout = 60
 				procFile = fmt.Sprintf("worker: while true; do echo hi; sleep 3; done")
-				testApp.URL = strings.Replace(url, "deis", testApp.Name, 1)
-				createApp(testApp.Name, "--no-remote")
-				createBuild(exampleImage, testApp)
+				testApp.URL = strings.Replace(getController(), "deis", testApp.Name, 1)
+				createApp(testData.Profile, testApp.Name, "--no-remote")
+				createBuild(testData.Profile, exampleImage, testApp)
 			})
 
 			It("can list app builds", func() {
-				cmd, err := start("deis builds:list -a %s", testApp.Name)
+				sess, err := start("deis builds:list -a %s", testData.Profile, testApp.Name)
+				Eventually(sess).Should(Say(uuidRegExp))
+				Eventually(sess).Should(Exit(0))
 				Expect(err).NotTo(HaveOccurred())
-				Eventually(cmd).Should(Exit(0))
-				Eventually(cmd).Should(Say(uuidRegExp))
 			})
 
 			It("can create a build from an existing image (\"deis pull\")", func() {
-				procsListing := listProcs(testApp).Out.Contents()
+				procsListing := listProcs(testData.Profile, testApp).Out.Contents()
 				// scrape current processes, should be 1 (cmd)
 				Expect(len(scrapeProcs(testApp.Name, procsListing))).To(Equal(1))
 
@@ -107,39 +110,40 @@ var _ = Describe("Builds", func() {
 				curlCmd = Cmd{CommandLineString: fmt.Sprintf(`curl -sL -w "%%{http_code}\\n" "%s" -o /dev/null`, testApp.URL)}
 				Eventually(cmdWithRetry(curlCmd, strconv.Itoa(http.StatusOK), cmdRetryTimeout)).Should(BeTrue())
 
-				deisPull(exampleImage, testApp, fmt.Sprintf(`--procfile="%s"`, procFile))
+				deisPull(testData.Profile, exampleImage, testApp, fmt.Sprintf(`--procfile="%s"`, procFile))
 
-				sess, err := start("deis ps:scale worker=1 -a %s", testApp.Name)
-				Expect(err).NotTo(HaveOccurred())
+				sess, err := start("deis ps:scale worker=1 -a %s", testData.Profile, testApp.Name)
 				Eventually(sess).Should(Say("Scaling processes... but first,"))
 				Eventually(sess, defaultMaxTimeout).Should(Say(`done in \d+s`))
 				Eventually(sess).Should(Say("=== %s Processes", testApp.Name))
 				Eventually(sess).Should(Exit(0))
+				Expect(err).NotTo(HaveOccurred())
 
-				procsListing = listProcs(testApp).Out.Contents()
+				procsListing = listProcs(testData.Profile, testApp).Out.Contents()
 				// scrape current processes, should be 2 (1 cmd, 1 worker)
 				Expect(len(scrapeProcs(testApp.Name, procsListing))).To(Equal(2))
 
 				// TODO: https://github.com/deis/workflow-e2e/issues/84
 				// "deis logs -a %s", app
-				// sess, err = start("deis logs -a %s", testApp.Name)
+				// sess, err = start("deis logs -a %s", testData.Profile, testApp.Name)
 				// Expect(err).To(BeNil())
 				// Eventually(sess).Should(Say("hi"))
 				// Eventually(sess).Should(Exit(0))
+				// Expect(err).NotTo(HaveOccurred())
 
 				// curl app to make sure everything OK
 				curlCmd = Cmd{CommandLineString: fmt.Sprintf(`curl -sL -w "%%{http_code}\\n" "%s" -o /dev/null`, testApp.URL)}
 				Eventually(cmdWithRetry(curlCmd, strconv.Itoa(http.StatusOK), cmdRetryTimeout)).Should(BeTrue())
 
 				// can scale cmd down to 0
-				sess, err = start("deis ps:scale cmd=0 -a %s", testApp.Name)
-				Expect(err).NotTo(HaveOccurred())
+				sess, err = start("deis ps:scale cmd=0 -a %s", testData.Profile, testApp.Name)
 				Eventually(sess).Should(Say("Scaling processes... but first,"))
 				Eventually(sess, defaultMaxTimeout).Should(Say(`done in \d+s`))
 				Eventually(sess).Should(Say("=== %s Processes", testApp.Name))
 				Eventually(sess).Should(Exit(0))
+				Expect(err).NotTo(HaveOccurred())
 
-				procsListing = listProcs(testApp).Out.Contents()
+				procsListing = listProcs(testData.Profile, testApp).Out.Contents()
 				// scrape current processes, should be 1 worker
 				Expect(len(scrapeProcs(testApp.Name, procsListing))).To(Equal(1))
 

--- a/tests/builds_test.go
+++ b/tests/builds_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Builds", func() {
 		var testApp App
 
 		BeforeEach(func() {
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
 			exampleRepo = "example-go"
 			exampleImage = fmt.Sprintf("deis/%s:latest", exampleRepo)
 			testApp.Name = getRandAppName()
@@ -63,6 +64,7 @@ var _ = Describe("Builds", func() {
 		Context("with existing app", func() {
 
 			BeforeEach(func() {
+				url, testUser, testPassword, testEmail, keyName = createRandomUser()
 				createApp(testApp.Name)
 				createBuild(exampleImage, testApp)
 			})
@@ -81,7 +83,8 @@ var _ = Describe("Builds", func() {
 			var procFile string
 
 			BeforeEach(func() {
-				cmdRetryTimeout = 10
+				url, testUser, testPassword, testEmail, keyName = createRandomUser()
+				cmdRetryTimeout = 60
 				procFile = fmt.Sprintf("worker: while true; do echo hi; sleep 3; done")
 				testApp.URL = strings.Replace(url, "deis", testApp.Name, 1)
 				createApp(testApp.Name, "--no-remote")

--- a/tests/certs_test.go
+++ b/tests/certs_test.go
@@ -141,6 +141,7 @@ var _ = Describe("Certs", func() {
 
 	Context("with an app yet to be deployed", func() {
 		BeforeEach(func() {
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
 			gitInit()
 			testApp = App{Name: getRandAppName()}
 			createApp(testApp.Name)
@@ -155,13 +156,9 @@ var _ = Describe("Certs", func() {
 
 		It("can add, attach, list, and remove certs", func() {
 			addDomain(domain, testApp.Name)
-
 			addCert(certName, certs["wildcard"].CertPath, certs["wildcard"].KeyPath)
-
 			Eventually(certsInfo(certName)).Should(Say("No connected domains"))
-
 			attachCert(certName, domain)
-
 			Eventually(certsInfo(certName)).Should(Say(domain))
 		})
 	})
@@ -170,6 +167,7 @@ var _ = Describe("Certs", func() {
 		once := &sync.Once{}
 
 		BeforeEach(func() {
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
 			// Set up the test app only once and assume the suite will clean up.
 			once.Do(func() {
 				os.Chdir(exampleRepo)

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"io/ioutil"
 	"os"
-	"sync"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -17,16 +16,13 @@ var _ = Describe("Config", func() {
 	Context("with a deployed app", func() {
 
 		var testApp App
-		once := &sync.Once{}
 
 		BeforeEach(func() {
-			// Set up the Processes test app only once and assume the suite will clean up.
-			once.Do(func() {
-				os.Chdir("example-go")
-				appName := getRandAppName()
-				createApp(appName)
-				testApp = deployApp(appName)
-			})
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
+			os.Chdir("example-go")
+			appName := getRandAppName()
+			createApp(appName)
+			testApp = deployApp(appName)
 		})
 
 		It("can set and list environment variables", func() {

--- a/tests/domains_test.go
+++ b/tests/domains_test.go
@@ -20,81 +20,82 @@ func getRandDomain() string {
 // TODO: move to sister dir/package 'common'
 //       for example, these could live in common/domains.go
 // demains-specific common actions and expectations
-func addDomain(domain, appName string) {
-	addOrRemoveDomain(domain, appName, "add")
+func addDomain(profile string, domain, appName string) {
+	addOrRemoveDomain(profile, domain, appName, "add")
 }
 
-func removeDomain(domain, appName string) {
-	addOrRemoveDomain(domain, appName, "remove")
+func removeDomain(profile string, domain, appName string) {
+	addOrRemoveDomain(profile, domain, appName, "remove")
 }
 
-func addOrRemoveDomain(domain, appName, addOrRemove string) {
+func addOrRemoveDomain(profile string, domain, appName, addOrRemove string) {
 	// Explicitly build literal substring since 'domain'
 	// may be a wildcard domain ('*.foo.com') and we don't want Gomega
 	// interpreting this string as a regexp
 	var substring string
 
-	sess, err := start("deis domains:%s %s --app=%s", addOrRemove, domain, appName)
-	Expect(err).NotTo(HaveOccurred())
+	sess, err := start("deis domains:%s %s --app=%s", profile, addOrRemove, domain, appName)
 	if addOrRemove == "add" {
 		substring = fmt.Sprintf("Adding %s to %s...", domain, appName)
 	} else {
 		substring = fmt.Sprintf("Removing %s from %s...", domain, appName)
 	}
 	Eventually(sess.Wait().Out.Contents()).Should(ContainSubstring(substring))
-	Eventually(sess).Should(Say("done"))
+	Eventually(sess, defaultMaxTimeout).Should(Say("done"))
 	Eventually(sess).Should(Exit(0))
+	Expect(err).NotTo(HaveOccurred())
 }
 
 var _ = Describe("Domains", func() {
 	var testApp App
 	var domain string
+	var testData TestData
 
 	Context("with app yet to be deployed", func() {
 
 		BeforeEach(func() {
-			url, testUser, testPassword, testEmail, keyName = createRandomUser()
+			testData = initTestData()
 			domain = getRandDomain()
 			gitInit()
 
 			testApp.Name = getRandAppName()
-			createApp(testApp.Name)
+			createApp(testData.Profile, testApp.Name)
 		})
 
 		It("can list domains", func() {
-			sess, err := start("deis domains:list --app=%s", testApp.Name)
-			Expect(err).NotTo(HaveOccurred())
+			sess, err := start("deis domains:list --app=%s", testData.Profile, testApp.Name)
 			Eventually(sess).Should(Say("=== %s Domains", testApp.Name))
 			Eventually(sess).Should(Say("%s", testApp.Name))
 			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("can add and remove domains", func() {
-			sess, err := start("deis domains:add %s --app=%s", domain, testApp.Name)
-			Expect(err).NotTo(HaveOccurred())
+			sess, err := start("deis domains:add %s --app=%s", testData.Profile, domain, testApp.Name)
 			Eventually(sess).Should(Say("Adding %s to %s...", domain, testApp.Name))
-			Eventually(sess).Should(Say("done"))
+			Eventually(sess, defaultMaxTimeout).Should(Say("done"))
 			Eventually(sess).Should(Exit(0))
-
-			sess, err = start("deis domains:remove %s --app=%s", domain, testApp.Name)
 			Expect(err).NotTo(HaveOccurred())
+
+			sess, err = start("deis domains:remove %s --app=%s", testData.Profile, domain, testApp.Name)
 			Eventually(sess).Should(Say("Removing %s from %s...", domain, testApp.Name))
-			Eventually(sess).Should(Say("done"))
+			Eventually(sess, defaultMaxTimeout).Should(Say("done"))
 		})
 	})
 
 	Context("with a deployed app", func() {
 		var curlCmd Cmd
 		var cmdRetryTimeout int
+		var testData TestData
 
 		BeforeEach(func() {
-			url, testUser, testPassword, testEmail, keyName = createRandomUser()
-			cmdRetryTimeout = 15
+			testData = initTestData()
+			cmdRetryTimeout = 60
 			domain = getRandDomain()
 			os.Chdir("example-go")
 			appName := getRandAppName()
-			createApp(appName)
-			testApp = deployApp(appName)
+			createApp(testData.Profile, appName)
+			testApp = deployApp(testData.Profile, appName)
 		})
 
 		AfterEach(func() {
@@ -102,23 +103,23 @@ var _ = Describe("Domains", func() {
 		})
 
 		It("can add, list, and remove domains", func() {
-			sess, err := start("deis domains:list --app=%s", testApp.Name)
-			Expect(err).NotTo(HaveOccurred())
+			sess, err := start("deis domains:list --app=%s", testData.Profile, testApp.Name)
 			Eventually(sess).Should(Say("=== %s Domains", testApp.Name))
 			Eventually(sess).Should(Say("%s", testApp.Name))
 			Eventually(sess).Should(Exit(0))
-
-			sess, err = start("deis domains:add %s --app=%s", domain, testApp.Name)
 			Expect(err).NotTo(HaveOccurred())
+
+			sess, err = start("deis domains:add %s --app=%s", testData.Profile, domain, testApp.Name)
 			Eventually(sess).Should(Say("Adding %s to %s...", domain, testApp.Name))
-			Eventually(sess).Should(Say("done"))
+			Eventually(sess, defaultMaxTimeout).Should(Say("done"))
 			Eventually(sess).Should(Exit(0))
-
-			sess, err = start("deis domains:list --app=%s", testApp.Name)
 			Expect(err).NotTo(HaveOccurred())
+
+			sess, err = start("deis domains:list --app=%s", testData.Profile, testApp.Name)
 			Eventually(sess).Should(Say("=== %s Domains", testApp.Name))
 			Eventually(sess).Should(Say("%s", domain))
 			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 
 			// curl app at both root and custom domain, both should return http.StatusOK
 			curlCmd = Cmd{CommandLineString: fmt.Sprintf(`curl -sL -w "%%{http_code}\\n" "%s" -o /dev/null`, testApp.URL)}
@@ -126,24 +127,23 @@ var _ = Describe("Domains", func() {
 			curlCmd = Cmd{CommandLineString: fmt.Sprintf(`curl -sL -H "Host: %s" -w "%%{http_code}\\n" "%s" -o /dev/null`, domain, testApp.URL)}
 			Eventually(cmdWithRetry(curlCmd, strconv.Itoa(http.StatusOK), cmdRetryTimeout)).Should(BeTrue())
 
-			sess, err = start("deis domains:remove %s --app=%s", domain, testApp.Name)
-			Expect(err).NotTo(HaveOccurred())
+			sess, err = start("deis domains:remove %s --app=%s", testData.Profile, domain, testApp.Name)
 			Eventually(sess).Should(Say("Removing %s from %s...", domain, testApp.Name))
-			Eventually(sess).Should(Say("done"))
+			Eventually(sess, defaultMaxTimeout).Should(Say("done"))
 			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 
 			// attempt to remove non-existent domain
-			sess, err = start("deis domains:remove %s --app=%s", domain, testApp.Name)
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(sess.Err).Should(Say("404 Not Found"))
+			sess, err = start("deis domains:remove %s --app=%s", testData.Profile, domain, testApp.Name)
+			Eventually(sess.Err, defaultMaxTimeout).Should(Say("404 Not Found"))
 			Eventually(sess).Should(Exit(1))
 
-			sess, err = start("deis domains:list --app=%s", testApp.Name)
-			Expect(err).NotTo(HaveOccurred())
+			sess, err = start("deis domains:list --app=%s", testData.Profile, testApp.Name)
 			Eventually(sess).Should(Say("=== %s Domains", testApp.Name))
 			Eventually(sess).Should(Say("%s", testApp.Name))
 			Eventually(sess).Should(Not(Say("%s", domain)))
 			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 
 			// curl app at both root and custom domain, custom should return http.StatusNotFound
 			curlCmd = Cmd{CommandLineString: fmt.Sprintf(`curl -sL -w "%%{http_code}\\n" "%s" -o /dev/null`, testApp.URL)}

--- a/tests/domains_test.go
+++ b/tests/domains_test.go
@@ -53,16 +53,12 @@ var _ = Describe("Domains", func() {
 	Context("with app yet to be deployed", func() {
 
 		BeforeEach(func() {
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
 			domain = getRandDomain()
 			gitInit()
 
 			testApp.Name = getRandAppName()
 			createApp(testApp.Name)
-		})
-
-		AfterEach(func() {
-			destroyApp(testApp)
-			gitClean()
 		})
 
 		It("can list domains", func() {
@@ -92,6 +88,7 @@ var _ = Describe("Domains", func() {
 		var cmdRetryTimeout int
 
 		BeforeEach(func() {
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
 			cmdRetryTimeout = 15
 			domain = getRandDomain()
 			os.Chdir("example-go")
@@ -102,7 +99,6 @@ var _ = Describe("Domains", func() {
 
 		AfterEach(func() {
 			defer os.Chdir("..")
-			destroyApp(testApp)
 		})
 
 		It("can add, list, and remove domains", func() {

--- a/tests/healthcheck_test.go
+++ b/tests/healthcheck_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Healthcheck", func() {
 	Context("with a deployed app", func() {
 		// create and deploy an app
 		BeforeEach(func() {
-			login(url, testUser, testPassword)
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
 			sess, err := start("deis apps:create %s", appName)
 			Expect(err).To(BeNil())
 			Eventually(sess).Should(Exit(0))
@@ -24,16 +24,6 @@ var _ = Describe("Healthcheck", func() {
 			Expect(err).To(BeNil())
 			Eventually(sess).Should(Exit(0))
 			Eventually(sess).Should(Say("Creating build... done"))
-		})
-
-		// destroy the app
-		AfterEach(func() {
-			sess, err := start("deis apps:destroy --confirm=%s", appName)
-			Expect(err).To(BeNil())
-			Eventually(sess).Should(Exit(0))
-			Eventually(sess).Should(Say("Destroying %s...", appName))
-			Eventually(sess).Should(Say("done in "))
-			Eventually(sess).Should(Say("Git remote deis removed"))
 		})
 
 		// TODO: test is broken

--- a/tests/help_test.go
+++ b/tests/help_test.go
@@ -1,8 +1,6 @@
 package tests
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -12,13 +10,23 @@ const usage string = "Usage: deis <command> [<args>...]"
 
 var _ = Describe("Help", func() {
 
-	for _, flag := range []string{"--help", "-h", "help"} {
-		It(fmt.Sprintf("prints help on \"%s\"", flag), func() {
-			output, err := execute("deis " + flag)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(ContainSubstring(usage))
-		})
-	}
+	It("prints help on --help", func() {
+		output, err := execute("deis %s", "--help")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(ContainSubstring(usage))
+	})
+
+	It("prints help on -h", func() {
+		output, err := execute("deis %s", "-h")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(ContainSubstring(usage))
+	})
+
+	It("prints help on help", func() {
+		output, err := execute("deis %s", "help")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(ContainSubstring(usage))
+	})
 
 	It("defaults to a usage message", func() {
 		output, err := execute("deis")

--- a/tests/keys_test.go
+++ b/tests/keys_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 var _ = Describe("Keys", func() {
+	BeforeEach(func() {
+		url, testUser, testPassword, testEmail, keyName = createRandomUser()
+	})
+
 	It("can list and remove a key", func() {
 		output, err := execute("deis keys:list")
 		Expect(err).NotTo(HaveOccurred())
@@ -21,7 +25,7 @@ var _ = Describe("Keys", func() {
 
 	It("can create and remove keys", func() {
 		tempSSHKeyName := fmt.Sprintf("deiskey-%v", rand.Intn(1000))
-		tempSSHKeyPath := createKey(tempSSHKeyName)
+		tempSSHKeyPath := createKey(testUser, tempSSHKeyName)
 
 		sess, err := start("deis keys:add %s.pub", tempSSHKeyPath)
 		Expect(err).To(BeNil())

--- a/tests/limits_test.go
+++ b/tests/limits_test.go
@@ -1,10 +1,13 @@
 package tests
 
 import (
+	"fmt"
 	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
 )
 
 // TODO (bacongobbler): inspect kubectl for limits being applied to manifest
@@ -12,59 +15,66 @@ var _ = Describe("Limits", func() {
 	Context("with a deployed app", func() {
 
 		var testApp App
+		var testData TestData
 
 		BeforeEach(func() {
-			url, testUser, testPassword, testEmail, keyName = createRandomUser()
+			testData = initTestData()
 			os.Chdir("example-go")
 			appName := getRandAppName()
-			createApp(appName)
-			testApp = deployApp(appName)
+			createApp(testData.Profile, appName)
+			testApp = deployApp(testData.Profile, appName)
 		})
 
 		It("can list limits", func() {
-			sess, err := execute("deis limits:list -a %s", testApp.Name)
+			sess, err := start("deis limits:list -a %s", testData.Profile, testApp.Name)
+			Eventually(sess).Should(Say(fmt.Sprintf("=== %s Limits", testApp.Name)))
+			Eventually(sess).Should(Say("--- Memory\nUnlimited"))
+			Eventually(sess).Should(Say("--- CPU\nUnlimited"))
+			Eventually(sess).Should(Exit(0))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(sess).To(SatisfyAll(
-				ContainSubstring("=== %s Limits", testApp.Name),
-				ContainSubstring("--- Memory\nUnlimited"),
-				ContainSubstring("--- CPU\nUnlimited"),
-			))
 		})
 
 		It("can set a memory limit", func() {
-			sess, err := execute("deis limits:set cmd=64M -a %s", testApp.Name)
+			sess, err := start("deis limits:set cmd=64M -a %s", testData.Profile, testApp.Name)
+			Eventually(sess, defaultMaxTimeout).Should(Say("--- Memory\ncmd     64M"))
+			Eventually(sess).Should(Exit(0))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(sess).To(ContainSubstring("--- Memory\ncmd     64M"))
 			// Check that --memory also works too
-			sess, err = execute("deis limits:set --memory cmd=128M -a %s", testApp.Name)
+			sess, err = start("deis limits:set --memory cmd=128M -a %s", testData.Profile, testApp.Name)
+			Eventually(sess, defaultMaxTimeout).Should(Say("--- Memory\ncmd     128M"))
+			Eventually(sess).Should(Exit(0))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(sess).To(ContainSubstring("--- Memory\ncmd     128M"))
 		})
 
 		It("can set a CPU limit", func() {
-			sess, err := execute("deis limits:set --cpu cmd=1024 -a %s", testApp.Name)
+			sess, err := start("deis limits:set --cpu cmd=1024 -a %s", testData.Profile, testApp.Name)
+			Eventually(sess, defaultMaxTimeout).Should(Say("--- CPU\ncmd     1024"))
+			Eventually(sess).Should(Exit(0))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(sess).To(ContainSubstring("--- CPU\ncmd     1024"))
 		})
 
 		It("can unset a memory limit", func() {
-			sess, err := execute("deis limits:unset cmd -a %s", testApp.Name)
-			Expect(err).NotTo(HaveOccurred(), sess)
-			Expect(sess).To(ContainSubstring("--- Memory\nUnlimited"))
+			sess, err := start("deis limits:unset cmd -a %s", testData.Profile, testApp.Name)
+			Eventually(sess, defaultMaxTimeout).Should(Say("--- Memory\nUnlimited"))
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 
 			// Check that --memory works too
-			sess, err = execute("deis limits:set --memory cmd=64M -a %s", testApp.Name)
-			Expect(err).NotTo(HaveOccurred(), sess)
-			Expect(sess).To(ContainSubstring("--- Memory\ncmd     64M"))
-			sess, err = execute("deis limits:unset --memory cmd -a %s", testApp.Name)
-			Expect(err).NotTo(HaveOccurred(), sess)
-			Expect(sess).To(ContainSubstring("--- Memory\nUnlimited"))
+			sess, err = start("deis limits:set --memory cmd=64M -a %s", testData.Profile, testApp.Name)
+			Eventually(sess, defaultMaxTimeout).Should(Say("--- Memory\ncmd     64M"))
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
+			sess, err = start("deis limits:unset --memory cmd -a %s", testData.Profile, testApp.Name)
+			Eventually(sess, defaultMaxTimeout).Should(Say("--- Memory\nUnlimited"))
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("can unset a CPU limit", func() {
-			sess, err := execute("deis limits:unset --cpu cmd -a %s", testApp.Name)
-			Expect(err).NotTo(HaveOccurred(), sess)
-			Expect(sess).To(ContainSubstring("--- CPU\nUnlimited"))
+			sess, err := start("deis limits:unset --cpu cmd -a %s", testData.Profile, testApp.Name)
+			Eventually(sess, defaultMaxTimeout).Should(Say("--- CPU\nUnlimited"))
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/tests/limits_test.go
+++ b/tests/limits_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"os"
-	"sync"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,16 +12,13 @@ var _ = Describe("Limits", func() {
 	Context("with a deployed app", func() {
 
 		var testApp App
-		once := &sync.Once{}
 
 		BeforeEach(func() {
-			// Set up the Limits test app only once and assume the suite will clean up.
-			once.Do(func() {
-				os.Chdir("example-go")
-				appName := getRandAppName()
-				createApp(appName)
-				testApp = deployApp(appName)
-			})
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
+			os.Chdir("example-go")
+			appName := getRandAppName()
+			createApp(appName)
+			testApp = deployApp(appName)
 		})
 
 		It("can list limits", func() {

--- a/tests/perms_test.go
+++ b/tests/perms_test.go
@@ -5,12 +5,15 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
+
+	// "fmt"
 )
 
 var _ = Describe("Perms", func() {
 	var testApp App
 
 	BeforeEach(func() {
+		url, testUser, testPassword, testEmail, keyName = createRandomUser()
 		testApp.Name = getRandAppName()
 		gitInit()
 		createApp(testApp.Name)
@@ -22,10 +25,12 @@ var _ = Describe("Perms", func() {
 
 	Context("when logged in as an admin user", func() {
 		BeforeEach(func() {
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
 			login(url, testAdminUser, testAdminPassword)
 		})
 
 		It("can create, list, and delete admin permissions", func() {
+
 			output, err := execute("deis perms:create %s --admin", testUser)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output).To(
@@ -49,6 +54,7 @@ var _ = Describe("Perms", func() {
 		})
 
 		It("can create, list, and delete app permissions", func() {
+
 			sess, err := start("deis perms:create %s --app=%s", testUser, testApp.Name)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(sess).Should(Say("Adding %s to %s collaborators... done\n", testUser, testApp.Name))
@@ -72,7 +78,9 @@ var _ = Describe("Perms", func() {
 	})
 
 	Context("when logged in as a normal user", func() {
+
 		It("can't create, list, or delete admin permissions", func() {
+
 			output, err := execute("deis perms:create %s --admin", testAdminUser)
 			Expect(err).To(HaveOccurred())
 			Expect(output).To(ContainSubstring("403 Forbidden"))
@@ -88,6 +96,7 @@ var _ = Describe("Perms", func() {
 		})
 
 		It("can create, list, and delete app permissions", func() {
+
 			sess, err := start("deis perms:create %s --app=%s", testUser, testApp.Name)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(sess).Should(Say("Adding %s to %s collaborators... done\n", testUser, testApp.Name))

--- a/tests/ps_test.go
+++ b/tests/ps_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"math/rand"
+	"net/http"
 	"os"
 	"regexp"
 	"sort"
@@ -20,10 +21,10 @@ var procsRegexp = `(%s-v\d+-[\w-]+) up \(v\d+\)`
 // TODO: https://github.com/deis/workflow-e2e/issues/108
 //       for example, these could live in common/certs.go
 // certs-specific common actions and expectations
-func listProcs(testApp App) *Session {
-	sess, err := start("deis ps:list --app=%s", testApp.Name)
-	Expect(err).NotTo(HaveOccurred())
+func listProcs(profile string, testApp App) *Session {
+	sess, err := start("deis ps:list --app=%s", profile, testApp.Name)
 	Eventually(sess).Should(Say("=== %s Processes", testApp.Name))
+	Expect(err).NotTo(HaveOccurred())
 	Eventually(sess).Should(Exit(0))
 	return sess
 }
@@ -48,13 +49,14 @@ var _ = Describe("Processes", func() {
 	Context("with a deployed app", func() {
 
 		var testApp App
+		var testData TestData
 
 		BeforeEach(func() {
-			url, testUser, testPassword, testEmail, keyName = createRandomUser()
+			testData = initTestData()
 			os.Chdir("example-go")
 			appName := getRandAppName()
-			createApp(appName)
-			testApp = deployApp(appName)
+			createApp(testData.Profile, appName)
+			testApp = deployApp(testData.Profile, appName)
 		})
 
 		DescribeTable("can scale up and down",
@@ -62,28 +64,29 @@ var _ = Describe("Processes", func() {
 			func(scaleTo, respCode int) {
 				// TODO: need some way to choose between "web" and "cmd" here!
 				// scale the app's processes to the desired number
-				sess, err := start("deis ps:scale web=%d --app=%s", scaleTo, testApp.Name)
-				Expect(err).NotTo(HaveOccurred())
+				sess, err := start("deis ps:scale web=%d --app=%s", testData.Profile, scaleTo, testApp.Name)
 				Eventually(sess).Should(Say("Scaling processes... but first,"))
 				Eventually(sess, defaultMaxTimeout).Should(Say(`done in \d+s`))
 				Eventually(sess).Should(Say("=== %s Processes", testApp.Name))
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(sess).Should(Exit(0))
 
 				// test that there are the right number of processes listed
-				procsListing := listProcs(testApp).Out.Contents()
+				procsListing := listProcs(testData.Profile, testApp).Out.Contents()
 				procs := scrapeProcs(testApp.Name, procsListing)
 				Expect(len(procs)).To(Equal(scaleTo))
 
 				// curl the app's root URL and print just the HTTP response code
-				sess, err = start(`curl -sL -w "%%{http_code}\\n" "%s" -o /dev/null`, testApp.URL)
+				sess, err = start(`curl -sL -w "%%{http_code}\\n" "%s" -o /dev/null`, testData.Profile, testApp.URL)
 				Eventually(sess).Should(Say(strconv.Itoa(respCode)))
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(sess).Should(Exit(0))
 			},
 
 			Entry("scales to 1", 1, 200),
 			Entry("scales to 3", 3, 200),
 			PEntry("scales to 0", 0, 503),
-			PEntry("scales to 5", 5, 200),
+			PEntry("scales to 3", 3, 200),
 			PEntry("scales to 0", 0, 503),
 			PEntry("scales to 1", 1, 200),
 		)
@@ -93,11 +96,12 @@ var _ = Describe("Processes", func() {
 			func(restart string, scaleTo int, respCode int) {
 				// TODO: need some way to choose between "web" and "cmd" here!
 				// scale the app's processes to the desired number
-				sess, err := start("deis ps:scale web=%d --app=%s", scaleTo, testApp.Name)
-				Expect(err).NotTo(HaveOccurred())
+				sess, err := start("deis ps:scale web=%d --app=%s", testData.Profile, scaleTo, testApp.Name)
+
 				Eventually(sess).Should(Say("Scaling processes... but first,"))
 				Eventually(sess, defaultMaxTimeout).Should(Say(`done in \d+s`))
 				Eventually(sess).Should(Say("=== %s Processes", testApp.Name))
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(sess).Should(Exit(0))
 
 				// capture the process names
@@ -119,19 +123,20 @@ var _ = Describe("Processes", func() {
 					Expect(procsLen).To(BeNumerically(">", 0))
 					arg = beforeProcs[rand.Intn(procsLen)]
 				}
-				sess, err = start("deis ps:restart %s --app=%s", arg, testApp.Name)
-				Expect(err).NotTo(HaveOccurred())
+				sess, err = start("deis ps:restart %s --app=%s", testData.Profile, arg, testApp.Name)
+
 				Eventually(sess).Should(Say("Restarting processes... but first,"))
 				if scaleTo == 0 || restart == "by wrong type" {
-					Eventually(sess).Should(Say("Could not find any processes to restart"))
+					Eventually(sess, defaultMaxTimeout).Should(Say("Could not find any processes to restart"))
 				} else {
 					Eventually(sess, defaultMaxTimeout).Should(Say(`done in \d+s`))
 					Eventually(sess).Should(Say("=== %s Processes", testApp.Name))
 				}
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(sess).Should(Exit(0))
 
 				// capture the process names
-				procsListing := listProcs(testApp).Out.Contents()
+				procsListing := listProcs(testData.Profile, testApp).Out.Contents()
 				afterProcs := scrapeProcs(testApp.Name, procsListing)
 
 				// compare the before and after sets of process names
@@ -141,19 +146,19 @@ var _ = Describe("Processes", func() {
 				}
 
 				// curl the app's root URL and print just the HTTP response code
-				maxRetryIterations := 15
+				cmdRetryTimeout := 60
 				curlCmd := Cmd{CommandLineString: fmt.Sprintf(`curl -sL -w "%%{http_code}\\n" "%s" -o /dev/null`, testApp.URL)}
-				Eventually(cmdWithRetry(curlCmd, strconv.Itoa(respCode), maxRetryIterations)).Should(BeTrue())
+				Eventually(cmdWithRetry(curlCmd, strconv.Itoa(http.StatusOK), cmdRetryTimeout)).Should(BeTrue())
 			},
 
 			Entry("restarts one of 1", "one", 1, 200),
 			Entry("restarts all of 1", "all", 1, 200),
 			Entry("restarts all of 1 by type", "by type", 1, 200),
 			Entry("restarts all of 1 by wrong type", "by wrong type", 1, 200),
-			Entry("restarts one of 6", "one", 6, 200),
-			Entry("restarts all of 6", "all", 6, 200),
-			Entry("restarts all of 6 by type", "by type", 6, 200),
-			Entry("restarts all of 6 by wrong type", "by wrong type", 6, 200),
+			Entry("restarts one of 3", "one", 3, 200),
+			Entry("restarts all of 3", "all", 3, 200),
+			Entry("restarts all of 3 by type", "by type", 3, 200),
+			Entry("restarts all of 3 by wrong type", "by wrong type", 3, 200),
 			PEntry("restarts all of 0", "all", 0, 503),
 			PEntry("restarts all of 0 by type", "by type", 0, 503),
 			PEntry("restarts all of 0 by wrong type", "by wrong type", 0, 503),

--- a/tests/ps_test.go
+++ b/tests/ps_test.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
-	"sync"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -49,16 +48,13 @@ var _ = Describe("Processes", func() {
 	Context("with a deployed app", func() {
 
 		var testApp App
-		once := &sync.Once{}
 
 		BeforeEach(func() {
-			// Set up the Processes test app only once and assume the suite will clean up.
-			once.Do(func() {
-				os.Chdir("example-go")
-				appName := getRandAppName()
-				createApp(appName)
-				testApp = deployApp(appName)
-			})
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
+			os.Chdir("example-go")
+			appName := getRandAppName()
+			createApp(appName)
+			testApp = deployApp(appName)
 		})
 
 		DescribeTable("can scale up and down",

--- a/tests/releases_test.go
+++ b/tests/releases_test.go
@@ -17,13 +17,10 @@ var _ = Describe("Releases", func() {
 		exampleImage = "deis/example-go"
 
 		BeforeEach(func() {
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
 			gitInit()
 			testApp = App{Name: getRandAppName()}
 			createApp(testApp.Name)
-		})
-
-		AfterEach(func() {
-			gitClean()
 		})
 
 		It("can deploy the app", func() {

--- a/tests/releases_test.go
+++ b/tests/releases_test.go
@@ -1,8 +1,6 @@
 package tests
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
@@ -12,49 +10,50 @@ import (
 var _ = Describe("Releases", func() {
 	var testApp App
 	var exampleImage string
+	var testData TestData
 
 	Context("with a deployed app", func() {
 		exampleImage = "deis/example-go"
 
 		BeforeEach(func() {
-			url, testUser, testPassword, testEmail, keyName = createRandomUser()
+			testData = initTestData()
 			gitInit()
 			testApp = App{Name: getRandAppName()}
-			createApp(testApp.Name)
+			createApp(testData.Profile, testApp.Name)
 		})
 
 		It("can deploy the app", func() {
 			// generate v2 release
-			deisPull(exampleImage, testApp)
+			deisPull(testData.Profile, exampleImage, testApp)
 
 			// "can list releases"
-			sess, err := start("deis releases:list -a %s", testApp.Name)
-			Expect(err).To(BeNil())
-			Eventually(sess, (1 * time.Minute)).Should(Exit(0))
-			Eventually(sess).Should(Say("=== %s Releases", testApp.Name))
-			Eventually(sess).Should(Say(`v1\s+.*\s+%s created initial release`, testUser))
+			sess, err := start("deis releases:list -a %s", testData.Profile, testApp.Name)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess, defaultMaxTimeout).Should(Say("=== %s Releases", testApp.Name))
+			Eventually(sess).Should(Say(`v1\s+.*\s+%s created initial release`, testData.Username))
+			Eventually(sess).Should(Exit(0))
 
 			// generate v3 release
-			deisPull(exampleImage, testApp)
+			deisPull(testData.Profile, exampleImage, testApp)
 
 			// "can rollback to a previous release"
-			sess, err = start("deis releases:rollback v2 -a %s", testApp.Name)
-			Expect(err).To(BeNil())
-			Eventually(sess, (1 * time.Minute)).Should(Exit(0))
+			sess, err = start("deis releases:rollback v2 -a %s", testData.Profile, testApp.Name)
+			Expect(err).NotTo(HaveOccurred())
 			Eventually(sess).Should(Say(`Rolling back to`))
-			Eventually(sess).Should(Say(`...done`))
+			Eventually(sess, defaultMaxTimeout).Should(Say(`...done`))
+			Eventually(sess).Should(Exit(0))
 
 			// "can get info on releases"
-			sess, err = start("deis releases:info v2 -a %s", testApp.Name)
-			Expect(err).To(BeNil())
-			Eventually(sess, (1 * time.Minute)).Should(Exit(0))
-			Eventually(sess).Should(Say("=== %s Release v2", testApp.Name))
+			sess, err = start("deis releases:info v2 -a %s", testData.Profile, testApp.Name)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess, defaultMaxTimeout).Should(Say("=== %s Release v2", testApp.Name))
 			Eventually(sess).Should(Say(`config:\s+[\w-]+`))
-			Eventually(sess).Should(Say(`owner:\s+%s`, testUser))
-			Eventually(sess).Should(Say(`summary:\s+%s \w+`, testUser))
+			Eventually(sess).Should(Say(`owner:\s+%s`, testData.Username))
+			Eventually(sess).Should(Say(`summary:\s+%s \w+`, testData.Username))
 			// the below updated date has to match a string like 2015-12-22T21:20:31UTC
 			Eventually(sess).Should(Say(`updated:\s+[\w\-\:]+UTC`))
 			Eventually(sess).Should(Say(`uuid:\s+[0-9a-f\-]+`))
+			Eventually(sess).Should(Exit(0))
 
 			//TODO: add actions/validations around scenario described in
 			// https://github.com/deis/controller/issues/540

--- a/tests/tags_test.go
+++ b/tests/tags_test.go
@@ -17,48 +17,47 @@ var _ = Describe("Tags", func() {
 
 	Context("with a deployed app", func() {
 		var testApp App
+		var testData TestData
 
 		BeforeEach(func() {
 			// use the "kubectl" executable in the search $PATH
 			if _, err := exec.LookPath("kubectl"); err != nil {
 				Skip("kubectl not found in search $PATH")
 			}
-
-			url, testUser, testPassword, testEmail, keyName = createRandomUser()
+			testData = initTestData()
 			os.Chdir("example-go")
 			appName := getRandAppName()
-			createApp(appName)
-			testApp = deployApp(appName)
+			createApp(testData.Profile, appName)
+			testApp = deployApp(testData.Profile, appName)
 		})
 
 		It("can set and unset tags", func() {
 			// can list tags
-			sess, err := start("deis tags:list")
-			Expect(err).NotTo(HaveOccurred())
+			sess, err := start("deis tags:list", testData.Profile)
 			Eventually(sess).Should(Say("=== %s Tags", testApp.Name))
 			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 
 			// set an invalid tag
-			sess, err = start("deis tags:set munkafolyamat=yeah")
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(sess).ShouldNot(Say("=== %s Tags", testApp.Name))
+			sess, err = start("deis tags:set munkafolyamat=yeah", testData.Profile)
+			Eventually(sess, defaultMaxTimeout).ShouldNot(Say("=== %s Tags", testApp.Name))
 			Eventually(sess).ShouldNot(Say(`munkafolyamat\s+yeah`, testApp.Name))
 			Eventually(sess.Err).Should(Say("400 Bad Request"))
 			Eventually(sess).Should(Exit(1))
 
 			// list tags
-			sess, err = start("deis tags:list")
-			Expect(err).NotTo(HaveOccurred())
+			sess, err = start("deis tags:list", testData.Profile)
 			Eventually(sess).Should(Say("=== %s Tags", testApp.Name))
 			Eventually(sess).ShouldNot(Say(`munkafolyamat\s+yeah`, testApp.Name))
 			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 
 			// find a valid tag to set
 			cmd := "kubectl get nodes -o jsonpath={.items[*].metadata..labels}"
 			// use original $HOME dir or kubectl can't find its config
-			sess, err = start("HOME=%s %s", homeHome, cmd)
-			Expect(err).NotTo(HaveOccurred())
+			sess, err = start("HOME=%s %s", "", homeHome, cmd)
 			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 			// grep output like "map[kubernetes.io/hostname:192.168.64.2 node:worker1]"
 			re := regexp.MustCompile(`([\w\.]{0,253}/?[-_\.\w]{1,63}:[-_\.\w]{1,63})`)
 			pairs := re.FindAllString(string(sess.Out.Contents()), -1)
@@ -66,50 +65,50 @@ var _ = Describe("Tags", func() {
 			label := strings.Split(pairs[0], ":")
 
 			// set a valid tag
-			sess, err = start("deis tags:set %s=%s", label[0], label[1])
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(sess).Should(Say("=== %s Tags", testApp.Name))
+			sess, err = start("deis tags:set %s=%s", testData.Profile, label[0], label[1])
+			Eventually(sess, defaultMaxTimeout).Should(Say("=== %s Tags", testApp.Name))
 			Eventually(sess).Should(Say(`%s\s+%s`, label[0], label[1]))
 			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 
 			// list tags
-			sess, err = start("deis tags:list")
-			Expect(err).NotTo(HaveOccurred())
+			sess, err = start("deis tags:list", testData.Profile)
 			Eventually(sess).Should(Say("=== %s Tags", testApp.Name))
 			Eventually(sess).Should(Say(`%s\s+%s`, label[0], label[1]))
 			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 
 			// unset an invalid tag
-			sess, err = start("deis tags:unset munkafolyamat")
-			Expect(err).NotTo(HaveOccurred())
+			sess, err = start("deis tags:unset munkafolyamat", testData.Profile)
 			// TODO: should unsetting a bogus tag return 0 (success?)
-			Eventually(sess).Should(Exit(0))
-			Eventually(sess).Should(Say("=== %s Tags", testApp.Name))
+			Eventually(sess, defaultMaxTimeout).Should(Say("=== %s Tags", testApp.Name))
 			Eventually(sess).ShouldNot(Say(`munkafolyamat\s+yeah`, testApp.Name))
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 
 			// unset a valid tag
-			sess, err = start("deis tags:unset %s", label[0])
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(sess).Should(Say("=== %s Tags", testApp.Name))
-			Eventually(sess).Should(Exit(0))
+			sess, err = start("deis tags:unset %s", testData.Profile, label[0])
+			Eventually(sess, defaultMaxTimeout).Should(Say("=== %s Tags", testApp.Name))
 			Eventually(sess).ShouldNot(Say(`%s\s+%s`, label[0], label[1]))
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 
 			// list tags
-			sess, err = start("deis tags:list")
-			Expect(err).NotTo(HaveOccurred())
+			sess, err = start("deis tags:list", testData.Profile)
 			Eventually(sess).Should(Say("=== %s Tags", testApp.Name))
-			Eventually(sess).Should(Exit(0))
 			Eventually(sess).ShouldNot(Say(`%s\s+%s`, label[0], label[1]))
 			Eventually(sess).ShouldNot(Say(`munkafolyamat\s+yeah`, testApp.Name))
+			Eventually(sess).Should(Exit(0))
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
 	DescribeTable("can get command-line help for tags", func(cmd, expected string) {
 
-		sess, err := start(cmd)
-		Expect(err).NotTo(HaveOccurred())
+		sess, err := start(cmd, "")
 		Eventually(sess).Should(Say(expected))
 		Eventually(sess).Should(Exit(0))
+		Expect(err).NotTo(HaveOccurred())
 		// TODO: test that help output was more than five lines long
 	},
 

--- a/tests/users_test.go
+++ b/tests/users_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Users", func() {
 
 	Context("when logged in as a normal user", func() {
 		BeforeEach(func() {
-			login(url, testUser, testPassword)
+			url, testUser, testPassword, testEmail, keyName = createRandomUser()
 		})
 
 		It("can't list all users", func() {

--- a/tests/users_test.go
+++ b/tests/users_test.go
@@ -3,33 +3,23 @@ package tests
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Users", func() {
-	Context("when logged in as an admin user", func() {
-		BeforeEach(func() {
-			login(url, testAdminUser, testAdminPassword)
-		})
-
-		It("can list all users", func() {
-			output, err := execute("deis users:list")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(SatisfyAll(
-				HavePrefix("=== Users"),
-				ContainSubstring(testUser),
-				ContainSubstring(testAdminUser)))
-		})
-	})
-
 	Context("when logged in as a normal user", func() {
+		var testData TestData
+
 		BeforeEach(func() {
-			url, testUser, testPassword, testEmail, keyName = createRandomUser()
+			testData = initTestData()
 		})
 
 		It("can't list all users", func() {
-			output, err := execute("deis users:list")
-			Expect(err).To(HaveOccurred())
-			Expect(output).To(ContainSubstring("403 Forbidden"))
+			sess, err := start("deis users:list", testData.Profile)
+			Eventually(sess.Err, defaultMaxTimeout).Should(Say("403 Forbidden"))
+			Eventually(sess).Should(Exit(1))
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
This PR gives us the ability to run the e2e test suite in parallel. This dramatically speeds up the test run making it easier on the end user who is trying to get a crucial change. For example here is a sequential test run performed against my 4 node m4.xlarge cluster -

```
Ran 100 of 113 Specs in 2003.951 seconds
SUCCESS! -- 100 Passed | 0 Failed | 13 Pending | 0 Skipped PASS
```

That test run took almost 33 minutes to complete.

But when running the tests in parallel we can see results like the following:

```
Ran 100 of 113 Specs in 367.949 seconds
SUCCESS! -- 100 Passed | 0 Failed | 13 Pending | 0 Skipped
```
That is just over 6 minutes.

To accomplish this several changes were made to the test suite:

1. Use http to register and login all users. This allows us to store the login token in a `user.json` file within the `$TEST_HOME` directory. 

1. Use `DEIS_PROFILE` to ensure we use the correct user for each action. When running tests in parallel we cannot be certain that the right fork/exec of the deis cli command is using the correct logged in user. 

1. Removed (commented out) the reset all user tokens test. So this test was wreaking havoc on my test runs because it basically blanked out all login tokens I had generated up until that point. This meant other tests that were inflight would suddenly start getting 401's. Until we can figure out a better way to test this I suggest we leave it commented out.

1.  Made most tests use the `Eventually` matcher. This is more of a consistency thing than for the parallel tests.

1. Removed lots of clean up code. Because we reset the cluster after each run and each test generates its own data we no longer need to cleanup after ourselves. The one notable exception to this is the domains/certs tests as I wasnt sure if we needed to clean up between tests for them to behave properly. However, I am pretty sure that I can remove that as well @helgi, @mboersma?

1.  `defaultMaxTimeout` is now at 600 seconds and `DefaultEventuallyTimeout` is 60 seconds. For most of last week I was dealing with timeouts when running these tests in parallel. I eventually found out that my cluster was mostly to blame. That being said I found having a longer timeout eased some of the failures I was seeing.

1. Use `fmt.Fprintf(GinkgoWriter...)`. Because we are running tests in parallel we can no longer use the standard `fmt.Printf` or `fmt.Println` calls because the output is jumbled. The `GinkgoWriter` is setup to handle parallel test runs.

1. Use go-dev as base image for docker and quit building the tests binary. The reasoning behind this is that the test binary doesnt allow us to run the tests in parallel. That means we have to add the tests to the image and use the regular `ginkgo` command to execute them.

1. Made the `defaultMaxTimeout` and `DefaultEventuallyTimeout` configurable by environment variables.