### PR TITLE
fix(tests_suite_test.go): remove sleep

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -398,7 +398,6 @@ func initTestData() TestData {
 	Eventually(sess).Should(Exit(0))
 	Expect(err).NotTo(HaveOccurred())
 
-	time.Sleep(1 * time.Second) // wait for ssh key to propagate
 	return TestData{
 		Username:      username,
 		Password:      password,

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -127,7 +127,6 @@ var _ = BeforeSuite(func() {
 
 	// verify this user is an admin by running a privileged command
 	sess, err := start("deis users:list", adminTestData.Profile)
-	Expect(err).To(BeNil())
 	Eventually(sess).Should(Exit(0))
 	Expect(err).NotTo(HaveOccurred())
 })


### PR DESCRIPTION
… that was being used to wait for SSH key propagation (which no longer
should happen)

Fixes https://github.com/deis/workflow-e2e/issues/139