### PR TITLE
feat(apps): track created apps and delete their namespaces after all tests are done

### DIFF
--- a/apps/delete.go
+++ b/apps/delete.go
@@ -1,0 +1,21 @@
+package apps
+
+import (
+	"io/ioutil"
+	"os/exec"
+)
+
+// DeleteAll deletes all of the app names in appNames. It sends all successfully deleted apps on succCh and all deletion failures on errCh. After all deletion events have completed (with success or error), only doneCh will be closed. Note that succCh and errCh are never closed, to prevent accidental reception
+func DeleteAll(appNames []Name, succCh chan<- Name, errCh chan<- error, doneCh chan<- struct{}) {
+	for _, appName := range appNames {
+		cmd := exec.Command("kubectl", "delete", "ns", appName.String())
+		cmd.Stdout = ioutil.Discard
+		cmd.Stderr = ioutil.Discard
+		if err := cmd.Run(); err != nil {
+			errCh <- err
+			continue
+		}
+		succCh <- appName
+	}
+	close(doneCh)
+}

--- a/apps/set.go
+++ b/apps/set.go
@@ -7,6 +7,11 @@ import (
 // Name is the name of an app that was created by a test in the suite. It is a fmt.Stringer
 type Name string
 
+// NameFromString creates a new Name from a string representation of an app name
+func NameFromString(str string) Name {
+	return Name(str)
+}
+
 // String is the fmt.Stringer interface implementation
 func (a Name) String() string {
 	return string(a)

--- a/apps/set.go
+++ b/apps/set.go
@@ -1,0 +1,55 @@
+package apps
+
+import (
+	"sync"
+)
+
+// Name is the name of an app that was created by a test in the suite. It is a fmt.Stringer
+type Name string
+
+// String is the fmt.Stringer interface implementation
+func (a Name) String() string {
+	return string(a)
+}
+
+// Set is a concurrency-safe set of app names
+type Set struct {
+	rwm *sync.RWMutex
+	set map[Name]struct{}
+}
+
+// NewSet creates a new, empty set of AppNames
+func NewSet() *Set {
+	return &Set{rwm: new(sync.RWMutex), set: make(map[Name]struct{})}
+}
+
+// Add adds appName to the set and returns whether or not the app name was already in the set
+func (s *Set) Add(appName Name) bool {
+	s.rwm.Lock()
+	defer s.rwm.Unlock()
+	_, ok := s.set[appName]
+	s.set[appName] = struct{}{}
+	return !ok
+}
+
+// GetAll returns all app names in the set. Note that more app names can be added to or removed from the set after this call returns the set after this call returns.
+func (s *Set) GetAll() []Name {
+	s.rwm.RLock()
+	s.rwm.RUnlock()
+	ret := make([]Name, len(s.set))
+	i := 0
+	for appName := range s.set {
+		ret[i] = appName
+		i++
+	}
+	return ret
+}
+
+// Clear clears all app names from the set and returns how many were in it
+func (s *Set) Clear() int {
+	s.rwm.Lock()
+	defer s.rwm.Unlock()
+	n := len(s.set)
+	s.set = make(map[Name]struct{})
+	return n
+}

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -272,6 +272,11 @@ func createApp(profile string, name string, options ...string) *Session {
 	sess.Wait(defaultMaxTimeout)
 	Eventually(sess).Should(Say("created %s", name))
 
+	existed := appNameSet.Add(apps.NameFromString(name))
+	if existed {
+		fmt.Printf("Recoverable error: app %s was already created\n", name)
+	}
+
 	for _, option := range options {
 		if option == "--no-remote" {
 			noRemote = true

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
 
+	"github.com/deis/workflow-e2e/apps"
 	"github.com/onsi/ginkgo/reporters"
 )
 
@@ -48,14 +49,14 @@ type TestData struct {
 	ControllerURL string
 }
 
-var adminTestData TestData
-var testRoot, testHome, keyPath, gitSSH string
-
 var (
-	debug                      = os.Getenv("DEBUG") != ""
-	homeHome                   = os.Getenv("HOME")
-	defaultMaxTimeout          = getDefaultMaxTimeout()
-	errMissingRouterHostEnvVar = fmt.Errorf("missing %s", deisRouterServiceHost)
+	adminTestData                       TestData
+	testRoot, testHome, keyPath, gitSSH string
+	appNameSet                          = apps.NewSet()
+	debug                               = os.Getenv("DEBUG") != ""
+	homeHome                            = os.Getenv("HOME")
+	defaultMaxTimeout                   = getDefaultMaxTimeout()
+	errMissingRouterHostEnvVar          = fmt.Errorf("missing %s", deisRouterServiceHost)
 )
 
 const (
@@ -150,6 +151,7 @@ var _ = BeforeEach(func() {
 var _ = AfterSuite(func() {
 	os.Chdir(testHome)
 	os.Setenv("HOME", homeHome)
+	// Still TODO: remove all namespaces according to the return values of appNameSet.GetAll()
 })
 
 func logout() {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -151,7 +151,21 @@ var _ = BeforeEach(func() {
 var _ = AfterSuite(func() {
 	os.Chdir(testHome)
 	os.Setenv("HOME", homeHome)
-	// Still TODO: remove all namespaces according to the return values of appNameSet.GetAll()
+	deleteSuccCh := make(chan apps.Name)
+	deleteErrCh := make(chan error)
+	deleteDoneCh := make(chan struct{})
+	go apps.DeleteAll(appNameSet.GetAll(), deleteSuccCh, deleteErrCh, deleteDoneCh)
+	for {
+		select {
+		case appName := <-deleteSuccCh:
+			log.Printf("successfully deleted app namespace %s", appName)
+		case err := <-deleteErrCh:
+			log.Printf("error deleting app namespace (%s)", err)
+		case <-deleteDoneCh:
+			break
+		}
+	}
+
 })
 
 func logout() {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -158,9 +158,9 @@ var _ = AfterSuite(func() {
 	for {
 		select {
 		case appName := <-deleteSuccCh:
-			log.Printf("successfully deleted app namespace %s", appName)
+			fmt.Fprintf(GinkgoWriter, "successfully deleted app namespace %s", appName)
 		case err := <-deleteErrCh:
-			log.Printf("error deleting app namespace (%s)", err)
+			fmt.Fprintf(GinkgoWriter, "error deleting app namespace (%s)", err)
 		case <-deleteDoneCh:
 			break
 		}
@@ -288,7 +288,7 @@ func createApp(profile string, name string, options ...string) *Session {
 
 	existed := appNameSet.Add(apps.NameFromString(name))
 	if existed {
-		fmt.Printf("Recoverable error: app %s was already created\n", name)
+		fmt.Fprintf(GinkgoWriter, "Recoverable error: app %s was already created\n", name)
 	}
 
 	for _, option := range options {


### PR DESCRIPTION
this set will be used to track installed apps, so that the tests can delete all corresponding namespaces after all are finished

This PR was inspired from the discussion at https://github.com/deis/workflow-e2e/issues/142#issuecomment-204458448

Note that this still needs manual testing to ensure that app namespaces are properly cleaned up.