### PR TITLE
fix(tags): regex for tags did not include - in names

### DIFF
--- a/tests/tags_test.go
+++ b/tests/tags_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Tags", func() {
 			Eventually(sess).Should(Exit(0))
 			Expect(err).NotTo(HaveOccurred())
 			// grep output like "map[kubernetes.io/hostname:192.168.64.2 node:worker1]"
-			re := regexp.MustCompile(`([\w\.]{0,253}/?[-_\.\w]{1,63}:[-_\.\w]{1,63})`)
+			re := regexp.MustCompile(`([\-\w\.]{0,253}/?[-_\.\w]{1,63}:[-_\.\w]{1,63})`)
 			pairs := re.FindAllString(string(sess.Out.Contents()), -1)
 			// use the first key:value pair found
 			label := strings.Split(pairs[0], ":")


### PR DESCRIPTION
Example output is:

```
map[failure-domain.beta.kubernetes.io/region:us-central1 failure-domain.beta.kubernetes.io/zone:us-central1-b kubernetes.io/hostname:gke-helm-testing-64fa-747f4ea5-node-ctnu beta.kubernetes.io/instance-type:n1-standard-4 cloud.google.com/gke-nodepool:default-pool]
```
without - in regex then `failure-` was never matched (https://www.debuggex.com/r/9sqOvZrKzMc0zadY) but with it that would be included (https://www.debuggex.com/r/Yj_XRnGHtHW29JCl)