### PR TITLE
fix(*): Use max timeout waiting for build:create to exit

### DIFF
--- a/tests/cmd/builds/commands.go
+++ b/tests/cmd/builds/commands.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/deis/workflow-e2e/tests/cmd"
 	"github.com/deis/workflow-e2e/tests/model"
+	"github.com/deis/workflow-e2e/tests/settings"
 
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
@@ -30,6 +31,6 @@ func createOrPull(user model.User, app model.App, command string) {
 	sess, err := cmd.Start("deis %s --app=%s %s", &user, command, app.Name, ExampleImage)
 	Expect(err).NotTo(HaveOccurred())
 	Eventually(sess).Should(Say("Creating build..."))
-	Eventually(sess).Should(Exit(0))
+	Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(0))
 	time.Sleep(10 * time.Second)
 }


### PR DESCRIPTION
I'm noticing some failures that look like this:

```
23:25:00 $ deis auth:register http://deis.10.83.252.114.nip.io --username=test-91253 --password=asdf1234 --email=test-91253@deis.io
23:25:00 Registered test-91253
23:25:00 Logged in as test-91253
23:25:00 $ deis apps:create test-129088529 --no-remote
23:25:00 Creating Application... ...done, created test-129088529
23:25:00 remote available at ssh://git@deis.10.83.252.114.nip.io:2222/test-129088529.git
23:25:00 $ deis builds:create --app=test-129088529 deis/example-dockerfile-http
23:25:00 Creating build... ...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o.$ deis apps:destroy --app=test-129088529 --confirm=test-129088529
23:25:00 Destroying test-129088529...
23:25:00 ..o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...o...done in 9s
23:25:00 $ deis auth:cancel --username=test-91253 --password=asdf1234 --yes
23:25:00 Please log in again in order to cancel this account
23:25:00 o..Logged in as test-91253
23:25:00 Account cancelled
23:25:00 
23:25:00 
23:25:00 • Failure in Spec Setup (BeforeEach) [69.655 seconds]
23:25:00 deis tags
23:25:00 /go/src/github.com/deis/workflow-e2e/tests/tags_test.go:177
23:25:00   with an existing user
23:25:00   /go/src/github.com/deis/workflow-e2e/tests/tags_test.go:142
23:25:00     who owns an existing app that has already been deployed
23:25:00     /go/src/github.com/deis/workflow-e2e/tests/tags_test.go:140
23:25:00       that user can set a valid tag [BeforeEach]
23:25:00       /go/src/github.com/deis/workflow-e2e/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:354
23:25:00 
23:25:00       Timed out after 60.000s.
23:25:00       Expected process to exit.  It did not.
23:25:00 
23:25:00       /go/src/github.com/deis/workflow-e2e/tests/cmd/builds/commands.go:33
```

This is the result of not waiting long enough for `deis build:create` to exit.  Many of the test suite's `Eventually` assertions on operations that may be slow explicitly use `settings.MaxEventuallyTimeout` as a timeout value, instead of the default.  `deis build:create` was _not_ already being handled in that fashion, although it should be.  This PR corrects that.

This should further improve test stability.