### PR TITLE
ref(Dockerfile): Base the image on Alpine-- much smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,32 @@
-FROM quay.io/deis/go-dev:0.10.0
+FROM golang:1.6-alpine
 
-ENV JUNIT=true
+ENV K8S_VERSION=1.2.2 GLIDE_VERSION=0.10.2 GLIDE_HOME=/root GO15VENDOREXPERIMENT=1 JUNIT=true
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl wget openssh-client git g++ gcc libc6-dev make bzr git mercurial openssh-client subversion procps && \
-    rm -rf /var/lib/apt/lists/*
-
-#Install deis cli
-RUN wget https://dl.bintray.com/deis/deisci/deis-6c176d2-linux-amd64 && \
-    mv ./deis-6c176d2-linux-amd64 /bin/deis && \
-    chmod +x /bin/deis
-
-# Install the kubectl cli
-RUN curl -O https://storage.googleapis.com/kubernetes-release/release/v1.1.8/bin/linux/amd64/kubectl && \
-    chmod +x kubectl && \
-    mv kubectl /usr/local/bin/kubectl
+RUN apk add --update-cache \
+	bash \
+	curl \
+	git \
+	make \
+	openssh \
+	&& rm -rf /var/cache/apk/* \
+	&& go get -u -v \
+	github.com/tools/godep \
+	github.com/onsi/ginkgo/ginkgo \
+	&& curl -L https://dl.bintray.com/deis/deisci/deis-6c176d2-linux-amd64 -o /usr/local/bin/deis \
+	&& chmod +x /usr/local/bin/deis \
+	&& mkdir -p $GOPATH/src/k8s.io \
+	&& curl -L https://github.com/kubernetes/kubernetes/archive/v$K8S_VERSION.tar.gz | tar xvz -C $GOPATH/src/k8s.io \
+	&& mv $GOPATH/src/k8s.io/kubernetes-$K8S_VERSION $GOPATH/src/k8s.io/kubernetes \
+	&& cd $GOPATH/src/k8s.io/kubernetes \
+	&& CGO_ENABLED=0 godep go build -o /usr/local/bin/kubectl cmd/kubectl/kubectl.go \
+	&& cd ~ \
+	&& rm -rf $GOPATH/src/k8s.io/kubernetes \
+	&& curl -L https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.tar.gz | tar xvz -C /tmp \
+	&& mv /tmp/linux-amd64/glide /usr/local/bin \ 
+	&& rm -rf /tmp/linux-amd64
 
 COPY . /go/src/github.com/deis/workflow-e2e
+
 WORKDIR /go/src/github.com/deis/workflow-e2e
 
 RUN glide install


### PR DESCRIPTION
Fixes #172 

Low hanging, late Friday fruit...

This creates a substantially smaller e2e image.  It uses Alpine.  Experience shows this would not be good for a general purpose Go development environment, but for this focused use, it seems perfectly fine.

Tests pass:

```
[kent@mbp workflow-e2e]$ make docker-test-integration
docker run --rm -e GINKGO_NODES=15 -e DEIS_CONTROLLER_URL=http://deis.krancour.deis.ninja -e DEFAULT_EVENTUALLY_TIMEOUT= -e MAX_EVENTUALLY_TIMEOUT= -e JUNIT= -e DEBUG= -v /Users/kent/.kube:/root/.kube -w /go/src/github.com/deis/workflow-e2e 192.168.99.100:5000/krancour/workflow-e2e:git-9139411 make test-integration
fatal: Not a git repository (or any of the parent directories): .git
ginkgo -slowSpecThreshold=120.00 -noisyPendings=false -nodes=15 tests/
Running Suite: Deis Workflow
============================
Random Seed: 1460773644
Will run 134 of 137 specs

Running in parallel across 15 nodes

P•••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••P•••••••••••••••••••P••••••••••••••••••••••••••••••
Ran 134 of 137 Specs in 451.949 seconds
SUCCESS! -- 134 Passed | 0 Failed | 3 Pending | 0 Skipped 

Ginkgo ran 1 suite in 7m39.708157588s
Test Suite Passed
```