### PR TITLE
tests(*): add specs for all buildpack & dockerfile example apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,13 @@ ifdef FOCUS_TEST
 FOCUS_OPTS := --focus="${FOCUS_TEST}"
 endif
 
-TEST_OPTS := -slowSpecThreshold=120.00 -noisyPendings=false ${GINKO_NODES_ARG} ${FOCUS_OPTS}
+ifdef SKIP_TEST
+SKIP_OPTS := --skip="${SKIP_TEST}"
+else  # Skip the lengthy "all buildpacks" and "all dockerfiles" specs by default
+SKIP_OPTS := --skip="all (buildpack|dockerfile) apps"
+endif
+
+TEST_OPTS := -slowSpecThreshold=120.00 -noisyPendings=false ${GINKO_NODES_ARG} ${SKIP_OPTS} ${FOCUS_OPTS}
 
 DEIS_REGISTRY ?= quay.io/
 IMAGE_PREFIX ?= deis
@@ -35,14 +41,15 @@ DEV_CMD_ARGS := --rm -v ${CURDIR}:${SRC_PATH} -w ${SRC_PATH} ${DEV_IMG}
 DEV_CMD := docker run ${DEV_CMD_ARGS}
 DEV_CMD_INT := docker run -it ${DEV_CMD_ARGS}
 RUN_CMD := docker run --rm -e GINKGO_NODES=${GINKGO_NODES} \
-													 -e FOCUS_OPTS=${FOCUS_OPTS} \
-													 -e DEIS_CONTROLLER_URL=${DEIS_CONTROLLER_URL} \
-													 -e DEFAULT_EVENTUALLY_TIMEOUT=${DEFAULT_EVENTUALLY_TIMEOUT} \
-													 -e MAX_EVENTUALLY_TIMEOUT=${MAX_EVENTUALLY_TIMEOUT} \
-													 -e JUNIT=${JUNIT} \
-													 -e DEBUG=${DEBUG} \
-													 -v ${HOME}/.kube:/root/.kube \
-													 -w ${SRC_PATH} ${IMAGE}
+	-e SKIP_OPTS=${SKIP_OPTS} \
+	-e FOCUS_OPTS=${FOCUS_OPTS} \
+	-e DEIS_CONTROLLER_URL=${DEIS_CONTROLLER_URL} \
+	-e DEFAULT_EVENTUALLY_TIMEOUT=${DEFAULT_EVENTUALLY_TIMEOUT} \
+	-e MAX_EVENTUALLY_TIMEOUT=${MAX_EVENTUALLY_TIMEOUT} \
+	-e JUNIT=${JUNIT} \
+	-e DEBUG=${DEBUG} \
+	-v ${HOME}/.kube:/root/.kube \
+	-w ${SRC_PATH} ${IMAGE}
 
 check-controller-url:
 	@if [ -z "$$DEIS_CONTROLLER_URL" ]; then \

--- a/tests/buildpacks_test.go
+++ b/tests/buildpacks_test.go
@@ -1,0 +1,97 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/deis/workflow-e2e/tests/cmd"
+	"github.com/deis/workflow-e2e/tests/cmd/apps"
+	"github.com/deis/workflow-e2e/tests/cmd/auth"
+	"github.com/deis/workflow-e2e/tests/cmd/git"
+	"github.com/deis/workflow-e2e/tests/cmd/keys"
+	"github.com/deis/workflow-e2e/tests/model"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("all buildpack apps", func() {
+
+	Context("with an existing user", func() {
+
+		var user model.User
+		var keyPath string
+
+		BeforeEach(func() {
+			user = auth.Register()
+		})
+
+		AfterEach(func() {
+			auth.Cancel(user)
+		})
+
+		Context("who has added their public key", func() {
+
+			BeforeEach(func() {
+				_, keyPath = keys.Add(user)
+			})
+
+			DescribeTable("can deploy an example buildpack app",
+				func(url, buildpack, banner string) {
+
+					var app model.App
+
+					output, err := cmd.Execute(`git clone %s`, url)
+					Expect(err).NotTo(HaveOccurred(), output)
+					// infer app directory from URL
+					splits := strings.Split(url, "/")
+					dir := strings.TrimSuffix(splits[len(splits)-1], ".git")
+					os.Chdir(dir)
+					// create with custom buildpack if needed
+					var args []string
+					if buildpack != "" {
+						args = append(args, fmt.Sprintf("--buildpack %s", buildpack))
+					}
+					app = apps.Create(user, args...)
+					defer apps.Destroy(user, app)
+					git.Push(user, keyPath, app, banner)
+
+				},
+
+				// NOTE: Keep this list up-to-date with any example apps that are added
+				// under the github/deis org, or any third-party apps that increase coverage
+				// or prevent regressions.
+				Entry("Clojure", "https://github.com/deis/example-clojure-ring.git", "",
+					"Powered by Deis"),
+				Entry("Go", "https://github.com/deis/example-go.git", "",
+					"Powered by Deis"),
+				Entry("Java", "https://github.com/deis/example-java-jetty.git", "",
+					"Powered by Deis"),
+				Entry("Multi", "https://github.com/deis/example-multi", "",
+					"Heroku Multipack Test"),
+				Entry("NodeJS", "https://github.com/deis/example-nodejs-express.git", "",
+					"Powered by Deis"),
+				Entry("Perl", "https://github.com/deis/example-perl.git",
+					"https://github.com/miyagawa/heroku-buildpack-perl.git",
+					"Powered by Deis"),
+				Entry("PHP", "https://github.com/deis/example-php.git", "",
+					"Powered by Deis"),
+				Entry("Java (Play)", "https://github.com/deis/example-play.git", "",
+					"Powered by Deis"),
+				Entry("Python (Django)", "https://github.com/deis/example-python-django.git", "",
+					"Powered by Deis"),
+				Entry("Python (Flask)", "https://github.com/deis/example-python-flask.git", "",
+					"Powered by Deis"),
+				Entry("Ruby", "https://github.com/deis/example-ruby-sinatra.git", "",
+					"Powered by Deis"),
+				Entry("Scala", "https://github.com/deis/example-scala.git", "",
+					"Powered by Deis"),
+			)
+
+		})
+
+	})
+
+})

--- a/tests/cmd/git/commands.go
+++ b/tests/cmd/git/commands.go
@@ -17,7 +17,7 @@ import (
 // This allows each of these to be re-used easily in multiple contexts.
 
 // Push executes a `git push deis master` from the current directory using the provided key.
-func Push(user model.User, keyPath string, app model.App) {
+func Push(user model.User, keyPath string, app model.App, banner string) {
 	sess, err := cmd.Start("GIT_SSH=%s GIT_KEY=%s git push deis master", &user, settings.GitSSH, keyPath)
 	Expect(err).NotTo(HaveOccurred())
 	// sess.Wait(settings.MaxEventuallyTimeout)
@@ -31,5 +31,5 @@ func Push(user model.User, keyPath string, app model.App) {
 	Eventually(cmd.Retry(curlCmd, strconv.Itoa(http.StatusOK), cmdRetryTimeout)).Should(BeTrue())
 	// verify that the response contains "Powered by" as all the example apps do
 	curlCmd = model.Cmd{CommandLineString: fmt.Sprintf(`curl -sL "%s"`, app.URL)}
-	Eventually(cmd.Retry(curlCmd, "Powered by", cmdRetryTimeout)).Should(BeTrue())
+	Eventually(cmd.Retry(curlCmd, banner, cmdRetryTimeout)).Should(BeTrue())
 }

--- a/tests/dockerfiles_test.go
+++ b/tests/dockerfiles_test.go
@@ -1,0 +1,73 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/deis/workflow-e2e/tests/cmd"
+	"github.com/deis/workflow-e2e/tests/cmd/apps"
+	"github.com/deis/workflow-e2e/tests/cmd/auth"
+	"github.com/deis/workflow-e2e/tests/cmd/git"
+	"github.com/deis/workflow-e2e/tests/cmd/keys"
+	"github.com/deis/workflow-e2e/tests/model"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("all dockerfile apps", func() {
+
+	Context("with an existing user", func() {
+
+		var user model.User
+		var keyPath string
+
+		BeforeEach(func() {
+			user = auth.Register()
+		})
+
+		AfterEach(func() {
+			auth.Cancel(user)
+		})
+
+		Context("who has added their public key", func() {
+
+			BeforeEach(func() {
+				_, keyPath = keys.Add(user)
+			})
+
+			DescribeTable("can deploy an example dockerfile app",
+				func(url, buildpack, banner string) {
+
+					var app model.App
+
+					output, err := cmd.Execute(`git clone %s`, url)
+					Expect(err).NotTo(HaveOccurred(), output)
+					// infer app directory from URL
+					splits := strings.Split(url, "/")
+					dir := strings.TrimSuffix(splits[len(splits)-1], ".git")
+					os.Chdir(dir)
+					// creeate with custom buildpack if needed
+					var args []string
+					if buildpack != "" {
+						args = append(args, fmt.Sprintf("--buildpack %s", buildpack))
+					}
+					app = apps.Create(user, args...)
+					defer apps.Destroy(user, app)
+					git.Push(user, keyPath, app, banner)
+
+				},
+
+				Entry("HTTP", "https://github.com/deis/example-dockerfile-http.git", "",
+					"Powered by Deis"),
+				Entry("Python", "https://github.com/deis/example-dockerfile-python.git", "",
+					"Powered by Deis"),
+			)
+
+		})
+
+	})
+
+})

--- a/tests/git_push_test.go
+++ b/tests/git_push_test.go
@@ -56,7 +56,7 @@ var _ = Describe("git push deis master", func() {
 					})
 
 					Specify("that user can deploy that app using a git push", func() {
-						git.Push(user, keyPath, app)
+						git.Push(user, keyPath, app, "Powered by Deis")
 					})
 
 				})
@@ -84,7 +84,7 @@ var _ = Describe("git push deis master", func() {
 					})
 
 					Specify("that user can deploy that app using a git push", func() {
-						git.Push(user, keyPath, app)
+						git.Push(user, keyPath, app, "Powered by Deis")
 					})
 
 				})


### PR DESCRIPTION
This adds specs that cover deploying all the deis/example-* apps. These can take a while to run, so they are disabled by default. You can run *only* these tests by providing a bogus match to the new `$SKIP_TEST` var and a correct regex to `$FOCUS_TEST`:
```console
$ SKIP_TEST=none FOCUS_TEST='all (buildpack|dockerfile) apps' make test-integration
ginkgo -slowSpecThreshold=120.00 -noisyPendings=false -p --skip="none" --focus="all (buildpack|dockerfile) apps" tests/
Running Suite: Deis Workflow
============================
Random Seed: 1462228973
Will run 14 of 170 specs
...
```

See also #179 for the introduction of `$FOCUS_TEST`.

TODO:
- [x] figure out why example-scala is failing (out of memory?)
- [x] ~~create a nightly Jenkins job to focus on these tests~~ See deis/jenkins-jobs#84