### PR TITLE
test(git_push): add concurrent push specs

### DIFF
--- a/tests/git_push_test.go
+++ b/tests/git_push_test.go
@@ -2,6 +2,8 @@ package tests
 
 import (
 	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/deis/workflow-e2e/tests/cmd"
 	"github.com/deis/workflow-e2e/tests/cmd/apps"
@@ -9,9 +11,12 @@ import (
 	"github.com/deis/workflow-e2e/tests/cmd/git"
 	"github.com/deis/workflow-e2e/tests/cmd/keys"
 	"github.com/deis/workflow-e2e/tests/model"
+	"github.com/deis/workflow-e2e/tests/settings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("git push deis master", func() {
@@ -70,6 +75,59 @@ var _ = Describe("git push deis master", func() {
 							})
 					})
 
+					Specify("that user can deploy that app only once concurrently", func() {
+						sess := git.StartPush(user, keyPath)
+						// sleep for five seconds, then push the same app
+						time.Sleep(5000 * time.Millisecond)
+						sess2 := git.StartPush(user, keyPath)
+						Eventually(sess2.Err).Should(Say("fatal: remote error: Another git push is ongoing"))
+						Eventually(sess2).Should(Exit(128))
+						git.PushUntilResult(user, keyPath,
+							model.CmdResult{
+								Out:      nil,
+								Err:      []byte("Everything up-to-date"),
+								ExitCode: 0,
+							})
+						Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(0))
+						git.Curl(app, "Powered by Deis")
+					})
+
+					Context("and who has another local git repo containing buildpack source code", func() {
+
+						BeforeEach(func() {
+							os.Chdir("..")
+							output, err := cmd.Execute(`git clone https://github.com/deis/example-nodejs-express.git`)
+							Expect(err).NotTo(HaveOccurred(), output)
+						})
+
+						Context("and has run `deis apps:create` from within that repo", func() {
+
+							var app2 model.App
+
+							BeforeEach(func() {
+								os.Chdir("example-nodejs-express")
+								app2 = apps.Create(user)
+							})
+
+							AfterEach(func() {
+								apps.Destroy(user, app2)
+							})
+
+							Specify("that user can deploy both apps concurrently", func() {
+								os.Chdir(filepath.Join("..", "example-go"))
+								sess := git.StartPush(user, keyPath)
+								os.Chdir(filepath.Join("..", "example-nodejs-express"))
+								sess2 := git.StartPush(user, keyPath)
+								Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(0))
+								Eventually(sess2, settings.MaxEventuallyTimeout).Should(Exit(0))
+								git.Curl(app, "Powered by Deis")
+								git.Curl(app2, "Powered by Deis")
+							})
+
+						})
+
+					})
+
 				})
 
 			})
@@ -96,6 +154,59 @@ var _ = Describe("git push deis master", func() {
 
 					Specify("that user can deploy that app using a git push", func() {
 						git.Push(user, keyPath, app, "Powered by Deis")
+					})
+
+					Specify("that user can deploy that app only once concurrently", func() {
+						sess := git.StartPush(user, keyPath)
+						// sleep for five seconds, then push the same app
+						time.Sleep(5000 * time.Millisecond)
+						sess2 := git.StartPush(user, keyPath)
+						Eventually(sess2.Err).Should(Say("fatal: remote error: Another git push is ongoing"))
+						Eventually(sess2).Should(Exit(128))
+						git.PushUntilResult(user, keyPath,
+							model.CmdResult{
+								Out:      nil,
+								Err:      []byte("Everything up-to-date"),
+								ExitCode: 0,
+							})
+						Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(0))
+						git.Curl(app, "Powered by Deis")
+					})
+
+					Context("and who has another local git repo containing dockerfile source code", func() {
+
+						BeforeEach(func() {
+							os.Chdir("..")
+							output, err := cmd.Execute(`git clone https://github.com/deis/example-dockerfile-python.git`)
+							Expect(err).NotTo(HaveOccurred(), output)
+						})
+
+						Context("and has run `deis apps:create` from within that repo", func() {
+
+							var app2 model.App
+
+							BeforeEach(func() {
+								os.Chdir("example-dockerfile-python")
+								app2 = apps.Create(user)
+							})
+
+							AfterEach(func() {
+								apps.Destroy(user, app2)
+							})
+
+							Specify("that user can deploy both apps concurrently", func() {
+								os.Chdir(filepath.Join("..", "example-dockerfile-http"))
+								sess := git.StartPush(user, keyPath)
+								os.Chdir(filepath.Join("..", "example-dockerfile-python"))
+								sess2 := git.StartPush(user, keyPath)
+								Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(0))
+								Eventually(sess2, settings.MaxEventuallyTimeout).Should(Exit(0))
+								git.Curl(app, "Powered by Deis")
+								git.Curl(app2, "Powered by Deis")
+							})
+
+						})
+
 					})
 
 				})


### PR DESCRIPTION
```console
$ FOCUS_TEST="git push deis master" DEIS_CONTROLLER_URL=your.workflow.host make test-integration
...
Ran 6 of 179 Specs in 364.039 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 173 Skipped 
```
(Add `-v` in the Makefile `TEST_OPTS` to see hilariously interleaved buildpack/dockerfile output.)

Refs #224.

cc: @vdice.

TODO:
- [x] `curl` app endpoints in different app specs
- [x] loop until success in same app specs
- [x] use `filepath` for portability