### PR TITLE
fix(.): clean up docker-test-integration shell script

### DIFF
--- a/docker-test-integration.sh
+++ b/docker-test-integration.sh
@@ -6,11 +6,11 @@
 BASE_URL="https://storage.googleapis.com/workflow-cli"
 URL="$BASE_URL/deis-latest-linux-amd64"
 
-if [[ $CLI_VERSION -ne "latest" ]]; then
+if [[ "$CLI_VERSION" != "latest" ]]; then
 	URL="$BASE_URL/$CLI_VERSION/deis-$CLI_VERSION-linux-amd64"
 fi
 
 echo "Installing Workflow CLI version $CLI_VERSION"
-curl $URL -o /usr/local/bin/deis && chmod +x /usr/local/bin/deis
+curl "$URL" -o /usr/local/bin/deis && chmod +x /usr/local/bin/deis
 
 make test-integration


### PR DESCRIPTION
This doesn't fix the issue where `echo "Installing Workflow CLI version $CLI_VERSION"` is not properly printing the version, but it does clean up the script a bit.