### PR TITLE
feat(git_push_test): add broken Dockerfile spec

### DIFF
--- a/tests/git_push_test.go
+++ b/tests/git_push_test.go
@@ -190,8 +190,7 @@ var _ = Describe("git push deis master", func() {
 						Specify("that user can't deploy that app using a git push", func() {
 							sess := git.StartPush(user, keyPath)
 							Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(1))
-							// TODO: this output doesn't show up 100% of the time! Needs a fix in dockerbuilder.
-							// Eventually(sess.Err).Should(Say("Unknown instruction: BOGUS"))
+							Eventually(sess.Err).Should(Say("Unknown instruction: BOGUS"))
 							Eventually(sess.Err).Should(Say("error: failed to push some refs"))
 						})
 

--- a/tests/git_push_test.go
+++ b/tests/git_push_test.go
@@ -173,6 +173,30 @@ var _ = Describe("git push deis master", func() {
 						git.Curl(app, "Powered by Deis")
 					})
 
+					Context("with a bad Dockerfile", func() {
+
+						BeforeEach(func() {
+							badCommit := `echo "BOGUS command" >> Dockerfile && EMAIL="ci@deis.com" git commit Dockerfile -m "Added a bogus command"`
+							output, err := cmd.Execute(badCommit)
+							Expect(err).NotTo(HaveOccurred(), output)
+						})
+
+						AfterEach(func() {
+							undoCommit := `git reset --hard HEAD~`
+							output, err := cmd.Execute(undoCommit)
+							Expect(err).NotTo(HaveOccurred(), output)
+						})
+
+						Specify("that user can't deploy that app using a git push", func() {
+							sess := git.StartPush(user, keyPath)
+							Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(1))
+							// TODO: this output doesn't show up 100% of the time! Needs a fix in dockerbuilder.
+							// Eventually(sess.Err).Should(Say("Unknown instruction: BOGUS"))
+							Eventually(sess.Err).Should(Say("error: failed to push some refs"))
+						})
+
+					})
+
 					Context("and who has another local git repo containing dockerfile source code", func() {
 
 						BeforeEach(func() {


### PR DESCRIPTION
Adds a ginkgo test spec to ensure that `git push` of a broken Dockerfile fails predictably.

Refs #85, deis/dockerbuilder#74, deis/workflow-e2e#185.

TODO:
- [x] fix deis/dockerbuilder#76 and enable the [`// TODO:` line](https://github.com/deis/workflow-e2e/pull/249/files#diff-fc0ae1eee55446a11f1785e18d8b5613R193)
- [x] fix CI `git` environment that apparently breaks some of these commands