### PR TITLE
feat(deployments): split out tests for deployment specific tests

### DIFF
--- a/tests/cmd/configs/commands.go
+++ b/tests/cmd/configs/commands.go
@@ -1,0 +1,24 @@
+package configs
+
+import (
+	"github.com/deis/workflow-e2e/tests/cmd"
+	"github.com/deis/workflow-e2e/tests/model"
+	"github.com/deis/workflow-e2e/tests/settings"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+// The functions in this file implement SUCCESS CASES for commonly used `deis config` subcommands.
+// This allows each of these to be re-used easily in multiple contexts.
+
+// Set executes `deis config:set` on the specified app as the specified user.
+func Set(user model.User, app model.App, key string, value string) *Session {
+	sess, err := cmd.Start("deis config:set %s=%s --app=%s", &user, key, value, app.Name)
+	Expect(err).NotTo(HaveOccurred())
+	sess.Wait(settings.MaxEventuallyTimeout)
+	Eventually(sess).Should(Say("Creating config..."))
+	Eventually(sess).Should(Exit(0))
+	return sess
+}

--- a/tests/deployments_buildpacks_test.go
+++ b/tests/deployments_buildpacks_test.go
@@ -1,0 +1,99 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/deis/workflow-e2e/tests/cmd"
+	"github.com/deis/workflow-e2e/tests/cmd/apps"
+	"github.com/deis/workflow-e2e/tests/cmd/auth"
+	"github.com/deis/workflow-e2e/tests/cmd/configs"
+	"github.com/deis/workflow-e2e/tests/cmd/git"
+	"github.com/deis/workflow-e2e/tests/cmd/keys"
+	"github.com/deis/workflow-e2e/tests/model"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("all buildpack apps", func() {
+
+	Context("with an existing user", func() {
+
+		var user model.User
+		var keyPath string
+
+		BeforeEach(func() {
+			user = auth.Register()
+		})
+
+		AfterEach(func() {
+			auth.Cancel(user)
+		})
+
+		Context("who has added their public key", func() {
+
+			BeforeEach(func() {
+				_, keyPath = keys.Add(user)
+			})
+
+			DescribeTable("can deploy an example buildpack app",
+				func(url, buildpack, banner string) {
+
+					var app model.App
+
+					output, err := cmd.Execute(`git clone %s`, url)
+					Expect(err).NotTo(HaveOccurred(), output)
+					// infer app directory from URL
+					splits := strings.Split(url, "/")
+					dir := strings.TrimSuffix(splits[len(splits)-1], ".git")
+					os.Chdir(dir)
+					// create with custom buildpack if needed
+					var args []string
+					if buildpack != "" {
+						args = append(args, fmt.Sprintf("--buildpack %s", buildpack))
+					}
+					app = apps.Create(user, args...)
+					configs.Set(user, app, "DEIS_KUBERNETES_DEPLOYMENTS", "1")
+					defer apps.Destroy(user, app)
+					git.Push(user, keyPath, app, banner)
+
+				},
+
+				// NOTE: Keep this list up-to-date with any example apps that are added
+				// under the github/deis org, or any third-party apps that increase coverage
+				// or prevent regressions.
+				Entry("Clojure", "https://github.com/deis/example-clojure-ring.git", "",
+					"Powered by Deis"),
+				Entry("Go", "https://github.com/deis/example-go.git", "",
+					"Powered by Deis"),
+				Entry("Java", "https://github.com/deis/example-java-jetty.git", "",
+					"Powered by Deis"),
+				Entry("Multi", "https://github.com/deis/example-multi", "",
+					"Heroku Multipack Test"),
+				Entry("NodeJS", "https://github.com/deis/example-nodejs-express.git", "",
+					"Powered by Deis"),
+				Entry("Perl", "https://github.com/deis/example-perl.git",
+					"https://github.com/miyagawa/heroku-buildpack-perl.git",
+					"Powered by Deis"),
+				Entry("PHP", "https://github.com/deis/example-php.git", "",
+					"Powered by Deis"),
+				Entry("Java (Play)", "https://github.com/deis/example-play.git", "",
+					"Powered by Deis"),
+				Entry("Python (Django)", "https://github.com/deis/example-python-django.git", "",
+					"Powered by Deis"),
+				Entry("Python (Flask)", "https://github.com/deis/example-python-flask.git", "",
+					"Powered by Deis"),
+				Entry("Ruby", "https://github.com/deis/example-ruby-sinatra.git", "",
+					"Powered by Deis"),
+				Entry("Scala", "https://github.com/deis/example-scala.git", "",
+					"Powered by Deis"),
+			)
+
+		})
+
+	})
+
+})

--- a/tests/deployments_builds_test.go
+++ b/tests/deployments_builds_test.go
@@ -1,0 +1,151 @@
+package tests
+
+import (
+	deis "github.com/deis/controller-sdk-go"
+	"github.com/deis/workflow-e2e/tests/cmd"
+	"github.com/deis/workflow-e2e/tests/cmd/apps"
+	"github.com/deis/workflow-e2e/tests/cmd/auth"
+	"github.com/deis/workflow-e2e/tests/cmd/builds"
+	"github.com/deis/workflow-e2e/tests/cmd/configs"
+	"github.com/deis/workflow-e2e/tests/model"
+	"github.com/deis/workflow-e2e/tests/settings"
+	"github.com/deis/workflow-e2e/tests/util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("deis builds", func() {
+
+	Context("with an existing user", func() {
+
+		uuidRegExp := `[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}`
+
+		var user model.User
+
+		BeforeEach(func() {
+			user = auth.Register()
+		})
+
+		AfterEach(func() {
+			auth.Cancel(user)
+		})
+
+		Context("and an app that does not exist", func() {
+
+			bogusAppName := "bogus-app-name"
+
+			Specify("that user cannot create a build for that app", func() {
+				sess, err := cmd.Start("deis builds:create -a %s %s", &user, bogusAppName, builds.ExampleImage)
+				Eventually(sess.Err).Should(Say(util.PrependError(deis.ErrNotFound)))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(1))
+			})
+
+		})
+
+		Context("who owns an existing app that has not been deployed", func() {
+
+			var app model.App
+
+			BeforeEach(func() {
+				app = apps.Create(user, "--no-remote")
+				configs.Set(user, app, "DEIS_KUBERNETES_DEPLOYMENTS", "1")
+			})
+
+			AfterEach(func() {
+				apps.Destroy(user, app)
+			})
+
+			Specify("that user can list that app's builds", func() {
+				sess, err := cmd.Start("deis builds:list -a %s", &user, app.Name)
+				Eventually(sess).ShouldNot(Say(uuidRegExp))
+				Eventually(sess).Should(Exit(0))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			Specify("that user can create a new build of that app from an existing image", func() {
+				builds.Create(user, app)
+			})
+
+			Specify("that user can create a new build of that app from an existing image using `deis pull`", func() {
+				builds.Pull(user, app)
+			})
+
+			Specify("that user can't create a new build of that app from a nonexistent image using `deis pull`", func() {
+				// Docker Hub gives a "not found" 400 error
+				nonexistentImage := "deis/nonexistent:dummy"
+				sess, err := cmd.Start("deis pull --app=%s %s", &user, app.Name, nonexistentImage)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Say("Creating build..."))
+				Eventually(sess.Err).Should(Say(`image .* not found`))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(1))
+				// quay.io gives a "permission denied" 400 error
+				nonexistentImage = "quay.io/deis/nonexistent:dummy"
+				sess, err = cmd.Start("deis pull --app=%s %s", &user, app.Name, nonexistentImage)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Say("Creating build..."))
+				Eventually(sess.Err).Should(Say("Permission Denied attempting to pull image"))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(1))
+			})
+
+			Specify("that user can create multiple builds of that app with DEPLOY_BATCHES set to 5", func() {
+				builds.Pull(user, app)
+
+				// scale to 11
+				sess, err := cmd.Start("deis ps:scale cmd=11 --app=%s", &user, app.Name)
+				Eventually(sess).Should(Say("Scaling processes... but first,"))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say(`done in \d+s`))
+				Eventually(sess).Should(Say("=== %s Processes", app.Name))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				// configure 5 pods being rolled at once
+				sess, err = cmd.Start("deis config:set -a %s DEPLOY_BATCHES=5", &user, app.Name)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Say("Creating config"))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Config", app.Name))
+				Eventually(sess).Should(Say(`DEPLOY_BATCHES\s+5`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+			})
+
+		})
+
+		Context("who owns an existing app that has already been deployed", func() {
+
+			var app model.App
+
+			BeforeEach(func() {
+				app = apps.Create(user, "--no-remote")
+				configs.Set(user, app, "DEIS_KUBERNETES_DEPLOYMENTS", "1")
+				builds.Create(user, app)
+			})
+
+			AfterEach(func() {
+				apps.Destroy(user, app)
+			})
+
+			Specify("that user can list that app's builds", func() {
+				sess, err := cmd.Start("deis builds:list -a %s", &user, app.Name)
+				Eventually(sess).Should(Say(uuidRegExp))
+				Eventually(sess).Should(Exit(0))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			Specify("that user can create a new build of that app from an existing image", func() {
+				builds.Create(user, app)
+			})
+
+			Specify("that user can create a new build of that app from an existing image using `deis pull`", func() {
+				builds.Pull(user, app)
+			})
+
+		})
+
+	})
+
+})

--- a/tests/deployments_config_test.go
+++ b/tests/deployments_config_test.go
@@ -1,0 +1,284 @@
+package tests
+
+import (
+	"io/ioutil"
+
+	"github.com/deis/workflow-e2e/tests/cmd"
+	"github.com/deis/workflow-e2e/tests/cmd/apps"
+	"github.com/deis/workflow-e2e/tests/cmd/auth"
+	"github.com/deis/workflow-e2e/tests/cmd/builds"
+	"github.com/deis/workflow-e2e/tests/cmd/configs"
+	"github.com/deis/workflow-e2e/tests/model"
+	"github.com/deis/workflow-e2e/tests/settings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("deis config", func() {
+
+	Context("with an existing user", func() {
+
+		var user model.User
+
+		BeforeEach(func() {
+			user = auth.Register()
+		})
+
+		AfterEach(func() {
+			auth.Cancel(user)
+		})
+
+		Context("who owns an existing app that has already been deployed", func() {
+
+			var app model.App
+
+			BeforeEach(func() {
+				app = apps.Create(user, "--no-remote")
+				configs.Set(user, app, "DEIS_KUBERNETES_DEPLOYMENTS", "1")
+				builds.Create(user, app)
+			})
+
+			AfterEach(func() {
+				apps.Destroy(user, app)
+			})
+
+			Specify("that user can list environment variables on that app", func() {
+				sess, err := cmd.Start("deis config:list -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("=== %s Config", app.Name))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+			Specify("that user can set environment variables on that app", func() {
+				sess, err := cmd.Start("deis config:set -a %s POWERED_BY=midi-chlorians", &user, app.Name)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Say("Creating config"))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Config", app.Name))
+				Eventually(sess).Should(Say(`POWERED_BY\s+midi-chlorians`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis config:list -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("=== %s Config", app.Name))
+				Eventually(sess).Should(Say(`POWERED_BY\s+midi-chlorians`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis run env -a %s", &user, app.Name)
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("POWERED_BY=midi-chlorians"))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+			Specify("that user can set multiple environment variables at once on that app", func() {
+				sess, err := cmd.Start("deis config:set FOO=null BAR=nil -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("Creating config"))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Config", app.Name))
+				output := string(sess.Out.Contents())
+				Expect(output).To(MatchRegexp(`FOO\s+null`))
+				Expect(output).To(MatchRegexp(`BAR\s+nil`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis config:list -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("=== %s Config", app.Name))
+				output = string(sess.Out.Contents())
+				Expect(output).To(MatchRegexp(`FOO\s+null`))
+				Expect(output).To(MatchRegexp(`BAR\s+nil`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis run env -a %s", &user, app.Name)
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("FOO=null"))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("BAR=nil"))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+			Specify("that user can set an environment variable containing spaces on that app", func() {
+				sess, err := cmd.Start(`deis config:set -a %s POWERED_BY=the\ Deis\ team`, &user, app.Name)
+				Eventually(sess).Should(Say("Creating config"))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Config", app.Name))
+				Eventually(sess).Should(Say(`POWERED_BY\s+the Deis team`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis config:list -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("=== %s Config", app.Name))
+				Eventually(sess).Should(Say(`POWERED_BY\s+the Deis team`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis run -a %s env", &user, app.Name)
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("POWERED_BY=the Deis team"))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+			It("that user can set a multi-line environment variable on that app", func() {
+				value := `This is
+a
+multiline string.`
+
+				sess, err := cmd.Start(`deis config:set -a %s FOO='%s'`, &user, app.Name, value)
+				Eventually(sess).Should(Say("Creating config"))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Config", app.Name))
+				Eventually(sess).Should(Say(`FOO\s+%s`, value))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis config:list -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("=== %s Config", app.Name))
+				Eventually(sess).Should(Say(`FOO\s+%s`, value))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis run -a %s env", &user, app.Name)
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("FOO=%s", value))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+			Specify("that user can set an environment variable with non-ASCII and multibyte chars on that app", func() {
+				sess, err := cmd.Start("deis config:set FOO=讲台 BAR=Þorbjörnsson BAZ=ноль -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("Creating config"))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Config", app.Name))
+				output := string(sess.Out.Contents())
+				Expect(output).To(MatchRegexp(`FOO\s+讲台`))
+				Expect(output).To(MatchRegexp(`BAR\s+Þorbjörnsson`))
+				Expect(output).To(MatchRegexp(`BAZ\s+ноль`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis config:list -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("=== %s Config", app.Name))
+				output = string(sess.Out.Contents())
+				Expect(output).To(MatchRegexp(`FOO\s+讲台`))
+				Expect(output).To(MatchRegexp(`BAR\s+Þorbjörnsson`))
+				Expect(output).To(MatchRegexp(`BAZ\s+ноль`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis run -a %s env", &user, app.Name)
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(0))
+				output = string(sess.Out.Contents())
+				Expect(output).To(ContainSubstring("FOO=讲台"))
+				Expect(output).To(ContainSubstring("BAR=Þorbjörnsson"))
+				Expect(output).To(ContainSubstring("BAZ=ноль"))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+			Context("and has already has an environment variable set", func() {
+
+				BeforeEach(func() {
+					sess, err := cmd.Start(`deis config:set -a %s FOO=xyzzy`, &user, app.Name)
+					Eventually(sess).Should(Say("Creating config"))
+					Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Config", app.Name))
+					Eventually(sess).Should(Say(`FOO\s+xyzzy`))
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(Exit(0))
+				})
+
+				Specify("that user can unset that environment variable", func() {
+					sess, err := cmd.Start("deis config:unset -a %s FOO", &user, app.Name)
+					Eventually(sess).Should(Say("Removing config"))
+					Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Config", app.Name))
+					Eventually(sess).ShouldNot(Say(`FOO\s+xyzzy`))
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(Exit(0))
+
+					sess, err = cmd.Start("deis config:list -a %s", &user, app.Name)
+					Eventually(sess).Should(Say("=== %s Config", app.Name))
+					Eventually(sess).ShouldNot(Say(`FOO\s+xyzzy`))
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(Exit(0))
+
+					sess, err = cmd.Start("deis run -a %s env", &user, app.Name)
+					Eventually(sess, settings.MaxEventuallyTimeout).ShouldNot(Say("FOO=xyzzy"))
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(Exit(0))
+				})
+
+				Specify("that user can pull the configuration to an .env file", func() {
+					sess, err := cmd.Start("deis config:pull -a %s", &user, app.Name)
+					// TODO: ginkgo seems to redirect deis' file output here, so just examine
+					// the output stream rather than reading in the .env file. Bug?
+					Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("FOO=xyzzy"))
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(Exit(0))
+				})
+
+			})
+
+			Specify("that user can push configuration from an .env file", func() {
+				contents := []byte(`BIP=baz
+FOO=bar`)
+				err := ioutil.WriteFile(".env", contents, 0644)
+
+				sess, err := cmd.Start("deis config:push -a %s", &user, app.Name)
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(0))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis config:list -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("=== %s Config", app.Name))
+				Eventually(sess).Should(Say(`BIP\s+baz`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+		})
+
+	})
+
+	DescribeTable("any user can get command-line help for config", func(command string, expected string) {
+		sess, err := cmd.Start(command, nil)
+		Eventually(sess).Should(Say(expected))
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(sess).Should(Exit(0))
+		// TODO: test that help output was more than five lines long
+	},
+		Entry("helps on \"help config\"",
+			"deis help config", "Valid commands for config:"),
+		Entry("helps on \"config -h\"",
+			"deis config -h", "Valid commands for config:"),
+		Entry("helps on \"config --help\"",
+			"deis config --help", "Valid commands for config:"),
+		Entry("helps on \"help config:list\"",
+			"deis help config:list", "Lists environment variables for an application."),
+		Entry("helps on \"config:list -h\"",
+			"deis config:list -h", "Lists environment variables for an application."),
+		Entry("helps on \"config:list --help\"",
+			"deis config:list --help", "Lists environment variables for an application."),
+		Entry("helps on \"help config:set\"",
+			"deis help config:set", "Sets environment variables for an application."),
+		Entry("helps on \"config:set -h\"",
+			"deis config:set -h", "Sets environment variables for an application."),
+		Entry("helps on \"config:set --help\"",
+			"deis config:set --help", "Sets environment variables for an application."),
+		Entry("helps on \"help config:unset\"",
+			"deis help config:unset", "Unsets an environment variable for an application."),
+		Entry("helps on \"config:unset -h\"",
+			"deis config:unset -h", "Unsets an environment variable for an application."),
+		Entry("helps on \"config:unset --help\"",
+			"deis config:unset --help", "Unsets an environment variable for an application."),
+		Entry("helps on \"help config:pull\"",
+			"deis help config:pull", "Extract all environment variables from an application for local use."),
+		Entry("helps on \"config:pull -h\"",
+			"deis config:pull -h", "Extract all environment variables from an application for local use."),
+		Entry("helps on \"config:pull --help\"",
+			"deis config:pull --help", "Extract all environment variables from an application for local use."),
+		Entry("helps on \"help config:push\"",
+			"deis help config:push", "Sets environment variables for an application."),
+		Entry("helps on \"config:push -h\"",
+			"deis config:push -h", "Sets environment variables for an application."),
+		Entry("helps on \"config:push --help\"",
+			"deis config:push --help", "Sets environment variables for an application."),
+	)
+
+})

--- a/tests/deployments_dockerfiles_test.go
+++ b/tests/deployments_dockerfiles_test.go
@@ -1,0 +1,75 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/deis/workflow-e2e/tests/cmd"
+	"github.com/deis/workflow-e2e/tests/cmd/apps"
+	"github.com/deis/workflow-e2e/tests/cmd/auth"
+	"github.com/deis/workflow-e2e/tests/cmd/configs"
+	"github.com/deis/workflow-e2e/tests/cmd/git"
+	"github.com/deis/workflow-e2e/tests/cmd/keys"
+	"github.com/deis/workflow-e2e/tests/model"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("all dockerfile apps", func() {
+
+	Context("with an existing user", func() {
+
+		var user model.User
+		var keyPath string
+
+		BeforeEach(func() {
+			user = auth.Register()
+		})
+
+		AfterEach(func() {
+			auth.Cancel(user)
+		})
+
+		Context("who has added their public key", func() {
+
+			BeforeEach(func() {
+				_, keyPath = keys.Add(user)
+			})
+
+			DescribeTable("can deploy an example dockerfile app",
+				func(url, buildpack, banner string) {
+
+					var app model.App
+
+					output, err := cmd.Execute(`git clone %s`, url)
+					Expect(err).NotTo(HaveOccurred(), output)
+					// infer app directory from URL
+					splits := strings.Split(url, "/")
+					dir := strings.TrimSuffix(splits[len(splits)-1], ".git")
+					os.Chdir(dir)
+					// creeate with custom buildpack if needed
+					var args []string
+					if buildpack != "" {
+						args = append(args, fmt.Sprintf("--buildpack %s", buildpack))
+					}
+					app = apps.Create(user, args...)
+					configs.Set(user, app, "DEIS_KUBERNETES_DEPLOYMENTS", "1")
+					defer apps.Destroy(user, app)
+					git.Push(user, keyPath, app, banner)
+
+				},
+
+				Entry("HTTP", "https://github.com/deis/example-dockerfile-http.git", "",
+					"Powered by Deis"),
+				Entry("Python", "https://github.com/deis/example-dockerfile-python.git", "",
+					"Powered by Deis"),
+			)
+
+		})
+
+	})
+
+})

--- a/tests/deployments_git_push_test.go
+++ b/tests/deployments_git_push_test.go
@@ -1,0 +1,262 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/deis/workflow-e2e/tests/cmd"
+	"github.com/deis/workflow-e2e/tests/cmd/apps"
+	"github.com/deis/workflow-e2e/tests/cmd/auth"
+	"github.com/deis/workflow-e2e/tests/cmd/configs"
+	"github.com/deis/workflow-e2e/tests/cmd/git"
+	"github.com/deis/workflow-e2e/tests/cmd/keys"
+	"github.com/deis/workflow-e2e/tests/model"
+	"github.com/deis/workflow-e2e/tests/settings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("git push deis master", func() {
+
+	Context("with an existing user", func() {
+
+		var user model.User
+		var keyPath string
+
+		BeforeEach(func() {
+			user = auth.Register()
+		})
+
+		AfterEach(func() {
+			auth.Cancel(user)
+		})
+
+		Context("who has added their public key", func() {
+
+			BeforeEach(func() {
+				_, keyPath = keys.Add(user)
+			})
+
+			Context("and who has a local git repo containing buildpack source code", func() {
+
+				BeforeEach(func() {
+					output, err := cmd.Execute(`git clone https://github.com/deis/example-go.git`)
+					Expect(err).NotTo(HaveOccurred(), output)
+				})
+
+				Context("and has run `deis apps:create` from within that repo", func() {
+
+					var app model.App
+
+					BeforeEach(func() {
+						os.Chdir("example-go")
+						app = apps.Create(user)
+						configs.Set(user, app, "DEIS_KUBERNETES_DEPLOYMENTS", "1")
+					})
+
+					AfterEach(func() {
+						apps.Destroy(user, app)
+					})
+
+					Specify("that user can deploy that app using a git push", func() {
+						git.Push(user, keyPath, app, "Powered by Deis")
+					})
+
+					Specify("that user can interrupt the deploy of the app and recover", func() {
+						git.PushWithInterrupt(user, keyPath)
+
+						git.PushUntilResult(user, keyPath,
+							model.CmdResult{
+								Out:      nil,
+								Err:      []byte("Everything up-to-date"),
+								ExitCode: 0,
+							})
+					})
+
+					Specify("that user can deploy that app only once concurrently", func() {
+						sess := git.StartPush(user, keyPath)
+						// sleep for five seconds, then push the same app
+						time.Sleep(5000 * time.Millisecond)
+						sess2 := git.StartPush(user, keyPath)
+						Eventually(sess2.Err).Should(Say("fatal: remote error: Another git push is ongoing"))
+						Eventually(sess2).Should(Exit(128))
+						git.PushUntilResult(user, keyPath,
+							model.CmdResult{
+								Out:      nil,
+								Err:      []byte("Everything up-to-date"),
+								ExitCode: 0,
+							})
+						Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(0))
+						git.Curl(app, "Powered by Deis")
+					})
+
+					Context("and who has another local git repo containing buildpack source code", func() {
+
+						BeforeEach(func() {
+							os.Chdir("..")
+							output, err := cmd.Execute(`git clone https://github.com/deis/example-nodejs-express.git`)
+							Expect(err).NotTo(HaveOccurred(), output)
+						})
+
+						Context("and has run `deis apps:create` from within that repo", func() {
+
+							var app2 model.App
+
+							BeforeEach(func() {
+								os.Chdir("example-nodejs-express")
+								app2 = apps.Create(user)
+								configs.Set(user, app2, "DEIS_KUBERNETES_DEPLOYMENTS", "1")
+							})
+
+							AfterEach(func() {
+								apps.Destroy(user, app2)
+							})
+
+							Specify("that user can deploy both apps concurrently", func() {
+								os.Chdir(filepath.Join("..", "example-go"))
+								sess := git.StartPush(user, keyPath)
+								os.Chdir(filepath.Join("..", "example-nodejs-express"))
+								sess2 := git.StartPush(user, keyPath)
+								Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(0))
+								Eventually(sess2, settings.MaxEventuallyTimeout).Should(Exit(0))
+								git.Curl(app, "Powered by Deis")
+								git.Curl(app2, "Powered by Deis")
+							})
+
+						})
+
+					})
+
+					Specify("and can execute deis run successfully", func() {
+						git.Push(user, keyPath, app, "Powered by Deis")
+						sess, err := cmd.Start("deis run env -a %s", &user, app.Name)
+						Expect(err).NotTo(HaveOccurred())
+						Eventually(sess).Should(Exit(0))
+					})
+
+				})
+
+			})
+
+			Context("and who has a local git repo containing dockerfile source code", func() {
+
+				BeforeEach(func() {
+					output, err := cmd.Execute(`git clone https://github.com/deis/example-dockerfile-http.git`)
+					Expect(err).NotTo(HaveOccurred(), output)
+				})
+
+				Context("and has run `deis apps:create` from within that repo", func() {
+
+					var app model.App
+
+					BeforeEach(func() {
+						os.Chdir("example-dockerfile-http")
+						app = apps.Create(user)
+						configs.Set(user, app, "DEIS_KUBERNETES_DEPLOYMENTS", "1")
+					})
+
+					AfterEach(func() {
+						apps.Destroy(user, app)
+					})
+
+					Specify("that user can deploy that app using a git push", func() {
+						git.Push(user, keyPath, app, "Powered by Deis")
+					})
+
+					Specify("that user can deploy that app only once concurrently", func() {
+						sess := git.StartPush(user, keyPath)
+						// sleep for five seconds, then push the same app
+						time.Sleep(5000 * time.Millisecond)
+						sess2 := git.StartPush(user, keyPath)
+						Eventually(sess2.Err).Should(Say("fatal: remote error: Another git push is ongoing"))
+						Eventually(sess2).Should(Exit(128))
+						git.PushUntilResult(user, keyPath,
+							model.CmdResult{
+								Out:      nil,
+								Err:      []byte("Everything up-to-date"),
+								ExitCode: 0,
+							})
+						Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(0))
+						git.Curl(app, "Powered by Deis")
+					})
+
+					Context("with a bad Dockerfile", func() {
+
+						BeforeEach(func() {
+							badCommit := `echo "BOGUS command" >> Dockerfile && EMAIL="ci@deis.com" git commit Dockerfile -m "Added a bogus command"`
+							output, err := cmd.Execute(badCommit)
+							Expect(err).NotTo(HaveOccurred(), output)
+						})
+
+						AfterEach(func() {
+							undoCommit := `git reset --hard HEAD~`
+							output, err := cmd.Execute(undoCommit)
+							Expect(err).NotTo(HaveOccurred(), output)
+						})
+
+						Specify("that user can't deploy that app using a git push", func() {
+							sess := git.StartPush(user, keyPath)
+							Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(1))
+							Eventually(sess.Err).Should(Say("Unknown instruction: BOGUS"))
+							Eventually(sess.Err).Should(Say("error: failed to push some refs"))
+						})
+
+					})
+
+					Context("and who has another local git repo containing dockerfile source code", func() {
+
+						BeforeEach(func() {
+							os.Chdir("..")
+							output, err := cmd.Execute(`git clone https://github.com/deis/example-dockerfile-python.git`)
+							Expect(err).NotTo(HaveOccurred(), output)
+						})
+
+						Context("and has run `deis apps:create` from within that repo", func() {
+
+							var app2 model.App
+
+							BeforeEach(func() {
+								os.Chdir("example-dockerfile-python")
+								app2 = apps.Create(user)
+								configs.Set(user, app2, "DEIS_KUBERNETES_DEPLOYMENTS", "1")
+							})
+
+							AfterEach(func() {
+								apps.Destroy(user, app2)
+							})
+
+							Specify("that user can deploy both apps concurrently", func() {
+								os.Chdir(filepath.Join("..", "example-dockerfile-http"))
+								sess := git.StartPush(user, keyPath)
+								os.Chdir(filepath.Join("..", "example-dockerfile-python"))
+								sess2 := git.StartPush(user, keyPath)
+								Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(0))
+								Eventually(sess2, settings.MaxEventuallyTimeout).Should(Exit(0))
+								git.Curl(app, "Powered by Deis")
+								git.Curl(app2, "Powered by Deis")
+							})
+
+						})
+
+					})
+
+					Specify("and can execute deis run successfully", func() {
+						git.Push(user, keyPath, app, "Powered by Deis")
+						sess, err := cmd.Start("deis run env -a %s", &user, app.Name)
+						Expect(err).NotTo(HaveOccurred())
+						Eventually(sess).Should(Exit(0))
+					})
+
+				})
+
+			})
+
+		})
+
+	})
+
+})

--- a/tests/deployments_healthcheck_test.go
+++ b/tests/deployments_healthcheck_test.go
@@ -1,0 +1,207 @@
+package tests
+
+import (
+	"github.com/deis/workflow-e2e/tests/cmd"
+	"github.com/deis/workflow-e2e/tests/cmd/apps"
+	"github.com/deis/workflow-e2e/tests/cmd/auth"
+	"github.com/deis/workflow-e2e/tests/cmd/builds"
+	"github.com/deis/workflow-e2e/tests/cmd/configs"
+	"github.com/deis/workflow-e2e/tests/model"
+	"github.com/deis/workflow-e2e/tests/settings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("deis healthchecks", func() {
+
+	Context("with an existing user", func() {
+
+		var user model.User
+
+		BeforeEach(func() {
+			user = auth.Register()
+		})
+
+		AfterEach(func() {
+			auth.Cancel(user)
+		})
+
+		Context("who owns an existing app that has already been deployed", func() {
+
+			var app model.App
+
+			BeforeEach(func() {
+				app = apps.Create(user, "--no-remote")
+				configs.Set(user, app, "DEIS_KUBERNETES_DEPLOYMENTS", "1")
+				builds.Create(user, app)
+			})
+
+			AfterEach(func() {
+				apps.Destroy(user, app)
+			})
+
+			Specify("that user can list healthchecks on that app", func() {
+				sess, err := cmd.Start("deis healthchecks:list -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("=== %s Healthchecks", app.Name))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+			Specify("that user can set an exec liveness healthcheck", func() {
+				sess, err := cmd.Start("deis healthchecks:set -a %s liveness exec -- /bin/true", &user, app.Name)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Say("Applying livenessProbe healthcheck..."))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Healthchecks", app.Name))
+				Eventually(sess).Should(Say(`Exec Probe\: Command=\[/bin/true]`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis healthchecks:list -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("=== %s Healthchecks", app.Name))
+				Eventually(sess).Should(Say(`Exec Probe\: Command=\[/bin/true]`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+			// disable httpGet liveness checks as it won't pass for every app
+			// TODO(bacongobbler): somehow determine *what* port we need to set the liveness check for this app
+			XSpecify("that user can set a httpGet liveness healthcheck", func() {
+				sess, err := cmd.Start("deis healthchecks:set liveness httpGet -a %s 80", &user, app.Name)
+				Eventually(sess).Should(Say("Applying livenessProbe healthcheck..."))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Healthchecks", app.Name))
+				Eventually(sess).Should(Say(`HTTP GET Probe\: Path="/" Port=80 HTTPHeaders=\[]`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis healthchecks:list -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("=== %s Healthchecks", app.Name))
+				Eventually(sess).Should(Say(`HTTP GET Probe\: Path="/" Port=80 HTTPHeaders=\[]`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+			Specify("that user can set a tcpSocket liveness healthcheck", func() {
+				sess, err := cmd.Start("deis healthchecks:set liveness tcpSocket -a %s 80", &user, app.Name)
+				Eventually(sess).Should(Say("Applying livenessProbe healthcheck..."))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Healthchecks", app.Name))
+				Eventually(sess).Should(Say(`TCP Socket Probe\: Port=80`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis healthchecks:list -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("=== %s Healthchecks", app.Name))
+				Eventually(sess).Should(Say(`TCP Socket Probe\: Port=80`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+			Specify("that user can set an exec readiness healthcheck", func() {
+				sess, err := cmd.Start("deis healthchecks:set readiness exec -a %s -- /bin/true", &user, app.Name)
+				Eventually(sess).Should(Say("Applying readinessProbe healthcheck..."))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Healthchecks", app.Name))
+				Eventually(sess).Should(Say(`Exec Probe\: Command=\[/bin/true]`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis healthchecks:list -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("=== %s Healthchecks", app.Name))
+				Eventually(sess).Should(Say(`Exec Probe\: Command=\[/bin/true]`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+			Specify("that user can set a httpGet readiness healthcheck", func() {
+				sess, err := cmd.Start("deis healthchecks:set readiness httpGet -a %s 80", &user, app.Name)
+				Eventually(sess).Should(Say("Applying readinessProbe healthcheck..."))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Healthchecks", app.Name))
+				Eventually(sess).Should(Say(`HTTP GET Probe\: Path="/" Port=80 HTTPHeaders=\[]`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis healthchecks:list -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("=== %s Healthchecks", app.Name))
+				Eventually(sess).Should(Say(`HTTP GET Probe\: Path="/" Port=80 HTTPHeaders=\[]`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+			Specify("that user can set a tcpSocket readiness healthcheck", func() {
+				sess, err := cmd.Start("deis healthchecks:set readiness tcpSocket -a %s 80", &user, app.Name)
+				Eventually(sess).Should(Say("Applying readinessProbe healthcheck..."))
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Healthchecks", app.Name))
+				Eventually(sess).Should(Say(`TCP Socket Probe\: Port=80`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+
+				sess, err = cmd.Start("deis healthchecks:list -a %s", &user, app.Name)
+				Eventually(sess).Should(Say("=== %s Healthchecks", app.Name))
+				Eventually(sess).Should(Say(`TCP Socket Probe\: Port=80`))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+			Context("and already has a healthcheck set", func() {
+				BeforeEach(func() {
+					sess, err := cmd.Start(`deis healthchecks:set readiness exec -a %s -- /bin/true`, &user, app.Name)
+					Eventually(sess).Should(Say("Applying readinessProbe healthcheck..."))
+					Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Healthchecks", app.Name))
+					Eventually(sess).Should(Say(`Exec Probe\: Command=\[/bin/true]`))
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(Exit(0))
+				})
+
+				Specify("that user can unset that healthcheck", func() {
+					sess, err := cmd.Start("deis healthchecks:unset -a %s readiness", &user, app.Name)
+					Eventually(sess).Should(Say("Removing healthchecks..."))
+					Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Healthchecks", app.Name))
+					Eventually(sess).ShouldNot(Say(`Exec Probe\: Command=\[/bin/true]`))
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(Exit(0))
+
+					sess, err = cmd.Start("deis healthchecks:list -a %s", &user, app.Name)
+					Eventually(sess).Should(Say("=== %s Healthchecks", app.Name))
+					Eventually(sess).ShouldNot(Say(`Exec Probe\: Command=\[/bin/true]`))
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(Exit(0))
+				})
+			})
+		})
+	})
+
+	DescribeTable("any user can get command-line help for healthchecks", func(command string, expected string) {
+		sess, err := cmd.Start(command, nil)
+		Eventually(sess).Should(Say(expected))
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(sess).Should(Exit(0))
+		// TODO: test that help output was more than five lines long
+	},
+		Entry("helps on \"help healthchecks\"",
+			"deis help healthchecks", "Valid commands for healthchecks:"),
+		Entry("helps on \"healthchecks -h\"",
+			"deis healthchecks -h", "Valid commands for healthchecks:"),
+		Entry("helps on \"healthchecks --help\"",
+			"deis healthchecks --help", "Valid commands for healthchecks:"),
+		Entry("helps on \"help healthchecks:list\"",
+			"deis help healthchecks:list", "Lists healthchecks for an application."),
+		Entry("helps on \"healthchecks:list -h\"",
+			"deis healthchecks:list -h", "Lists healthchecks for an application."),
+		Entry("helps on \"healthchecks:list --help\"",
+			"deis healthchecks:list --help", "Lists healthchecks for an application."),
+		Entry("helps on \"help healthchecks:set\"",
+			"deis help healthchecks:set", "Sets healthchecks for an application."),
+		Entry("helps on \"healthchecks:set -h\"",
+			"deis healthchecks:set -h", "Sets healthchecks for an application."),
+		Entry("helps on \"healthchecks:set --help\"",
+			"deis healthchecks:set --help", "Sets healthchecks for an application."),
+		Entry("helps on \"help healthchecks:unset\"",
+			"deis help healthchecks:unset", "Unsets healthchecks for an application."),
+		Entry("helps on \"healthchecks:unset -h\"",
+			"deis healthchecks:unset -h", "Unsets healthchecks for an application."),
+		Entry("helps on \"healthchecks:unset --help\"",
+			"deis healthchecks:unset --help", "Unsets healthchecks for an application."),
+	)
+})

--- a/tests/deployments_ps_test.go
+++ b/tests/deployments_ps_test.go
@@ -1,0 +1,203 @@
+package tests
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+
+	"github.com/deis/workflow-e2e/tests/cmd"
+	"github.com/deis/workflow-e2e/tests/cmd/apps"
+	"github.com/deis/workflow-e2e/tests/cmd/auth"
+	"github.com/deis/workflow-e2e/tests/cmd/builds"
+	"github.com/deis/workflow-e2e/tests/cmd/configs"
+	"github.com/deis/workflow-e2e/tests/model"
+	"github.com/deis/workflow-e2e/tests/settings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("deis ps", func() {
+
+	Context("with an existing user", func() {
+
+		var user model.User
+
+		BeforeEach(func() {
+			user = auth.Register()
+		})
+
+		AfterEach(func() {
+			auth.Cancel(user)
+		})
+
+		Context("who owns an existing app that has already been deployed", func() {
+
+			var app model.App
+
+			BeforeEach(func() {
+				app = apps.Create(user, "--no-remote")
+				configs.Set(user, app, "DEIS_KUBERNETES_DEPLOYMENTS", "1")
+				builds.Create(user, app)
+			})
+
+			AfterEach(func() {
+				apps.Destroy(user, app)
+			})
+
+			DescribeTable("that user can scale that app up and down",
+				func(scaleTo, respCode int) {
+					sess, err := cmd.Start("deis ps:scale cmd=%d --app=%s", &user, scaleTo, app.Name)
+					Eventually(sess).Should(Say("Scaling processes... but first,"))
+					Eventually(sess, settings.MaxEventuallyTimeout).Should(Say(`done in \d+s`))
+					Eventually(sess).Should(Say("=== %s Processes", app.Name))
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(Exit(0))
+
+					// test that there are the right number of processes listed
+					procsListing := listDeploymentProcs(user, app).Out.Contents()
+					procs := scrapeDeploymentProcs(app.Name, procsListing)
+					Expect(len(procs)).To(Equal(scaleTo))
+
+					// curl the app's root URL and print just the HTTP response code
+					cmdRetryTimeout := 60
+					curlCmd := model.Cmd{CommandLineString: fmt.Sprintf(`curl -sL -w "%%{http_code}\\n" "%s" -o /dev/null`, app.URL)}
+					Eventually(cmd.Retry(curlCmd, strconv.Itoa(respCode), cmdRetryTimeout)).Should(BeTrue())
+				},
+				Entry("scales to 1", 1, 200),
+				Entry("scales to 3", 3, 200),
+				Entry("scales to 0", 0, 503),
+			)
+
+			// TODO: Test is broken
+			XIt("that app remains responsive during a scaling event", func() {
+				stopCh := make(chan struct{})
+				doneCh := make(chan struct{})
+
+				// start scaling the app
+				go func() {
+					for range stopCh {
+						sess, err := cmd.Start("deis ps:scale web=4 -a %s", &user, app.Name)
+						Eventually(sess).Should(Exit(0))
+						Expect(err).NotTo(HaveOccurred())
+					}
+					close(doneCh)
+				}()
+
+				for i := 0; i < 10; i++ {
+					// start the scale operation. waits until the last scale op has finished
+					stopCh <- struct{}{}
+					resp, err := http.Get(app.URL)
+					Expect(err).To(BeNil())
+					Expect(resp.StatusCode).To(BeEquivalentTo(http.StatusOK))
+				}
+
+				// wait until the goroutine that was scaling the app shuts down. not strictly necessary, just good practice
+				Eventually(doneCh).Should(BeClosed())
+			})
+
+			DescribeTable("that user can restart that app's processes",
+				func(restart string, scaleTo int, respCode int) {
+					// TODO: need some way to choose between "web" and "cmd" here!
+					// scale the app's processes to the desired number
+					sess, err := cmd.Start("deis ps:scale cmd=%d --app=%s", &user, scaleTo, app.Name)
+
+					Eventually(sess).Should(Say("Scaling processes... but first,"))
+					Eventually(sess, settings.MaxEventuallyTimeout).Should(Say(`done in \d+s`))
+					Eventually(sess).Should(Say("=== %s Processes", app.Name))
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(Exit(0))
+
+					// capture the process names
+					beforeProcs := scrapeDeploymentProcs(app.Name, sess.Out.Contents())
+
+					// restart the app's process(es)
+					var arg string
+					switch restart {
+					case "all":
+						arg = ""
+					case "by type":
+						// TODO: need some way to choose between "web" and "cmd" here!
+						arg = "cmd"
+					case "by wrong type":
+						// TODO: need some way to choose between "web" and "cmd" here!
+						arg = "web"
+					case "one":
+						procsLen := len(beforeProcs)
+						Expect(procsLen).To(BeNumerically(">", 0))
+						arg = beforeProcs[rand.Intn(procsLen)]
+					}
+					sess, err = cmd.Start("deis ps:restart %s --app=%s", &user, arg, app.Name)
+					Eventually(sess).Should(Say("Restarting processes... but first,"))
+					if scaleTo == 0 || restart == "by wrong type" {
+						Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("Could not find any processes to restart"))
+					} else {
+						Eventually(sess, settings.MaxEventuallyTimeout).Should(Say(`done in \d+s`))
+						Eventually(sess).Should(Say("=== %s Processes", app.Name))
+					}
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(Exit(0))
+
+					// capture the process names
+					procsListing := listDeploymentProcs(user, app).Out.Contents()
+					afterProcs := scrapeDeploymentProcs(app.Name, procsListing)
+
+					// compare the before and after sets of process names
+					Expect(len(afterProcs)).To(Equal(scaleTo))
+					if scaleTo > 0 && restart != "by wrong type" {
+						Expect(beforeProcs).NotTo(Equal(afterProcs))
+					}
+
+					// curl the app's root URL and print just the HTTP response code
+					cmdRetryTimeout := 60
+					curlCmd := model.Cmd{CommandLineString: fmt.Sprintf(`curl -sL -w "%%{http_code}\\n" "%s" -o /dev/null`, app.URL)}
+					Eventually(cmd.Retry(curlCmd, strconv.Itoa(respCode), cmdRetryTimeout)).Should(BeTrue())
+				},
+				Entry("restarts one of 1", "one", 1, 200),
+				Entry("restarts all of 1", "all", 1, 200),
+				Entry("restarts all of 1 by type", "by type", 1, 200),
+				Entry("restarts all of 1 by wrong type", "by wrong type", 1, 200),
+				Entry("restarts one of 3", "one", 3, 200),
+				Entry("restarts all of 3", "all", 3, 200),
+				Entry("restarts all of 3 by type", "by type", 3, 200),
+				Entry("restarts all of 3 by wrong type", "by wrong type", 3, 200),
+				Entry("restarts all of 0", "all", 0, 503),
+				Entry("restarts all of 0 by type", "by type", 0, 503),
+				Entry("restarts all of 0 by wrong type", "by wrong type", 0, 503),
+			)
+
+		})
+
+	})
+
+})
+
+func listDeploymentProcs(user model.User, app model.App) *Session {
+	sess, err := cmd.Start("deis ps:list --app=%s", &user, app.Name)
+	Eventually(sess).Should(Say("=== %s Processes", app.Name))
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(sess).Should(Exit(0))
+	return sess
+}
+
+// scrapeDeploymentProcs returns the sorted process names for an app from the given output.
+// It matches the current "deis ps" output for a healthy container:
+//   earthy-vocalist-cmd-123456789-1d73e up (v2)
+//   myapp-web-123456789-bujlq up (v16)
+func scrapeDeploymentProcs(app string, output []byte) []string {
+	procsRegexp := `(%s-[\w-]+) up \(v\d+\)`
+	re := regexp.MustCompile(fmt.Sprintf(procsRegexp, app))
+	found := re.FindAllSubmatch(output, -1)
+	procs := make([]string, len(found))
+	for i := range found {
+		procs[i] = string(found[i][1])
+	}
+	sort.Strings(procs)
+	return procs
+}

--- a/tests/deployments_releases_test.go
+++ b/tests/deployments_releases_test.go
@@ -1,0 +1,97 @@
+package tests
+
+import (
+	"github.com/deis/workflow-e2e/tests/cmd"
+	"github.com/deis/workflow-e2e/tests/cmd/apps"
+	"github.com/deis/workflow-e2e/tests/cmd/auth"
+	"github.com/deis/workflow-e2e/tests/cmd/builds"
+	"github.com/deis/workflow-e2e/tests/cmd/configs"
+	"github.com/deis/workflow-e2e/tests/model"
+	"github.com/deis/workflow-e2e/tests/settings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("deis releases", func() {
+
+	Context("with an existing user", func() {
+
+		var user model.User
+
+		BeforeEach(func() {
+			user = auth.Register()
+		})
+
+		AfterEach(func() {
+			auth.Cancel(user)
+		})
+
+		Context("who owns an existing app that has already been deployed", func() {
+
+			var app model.App
+
+			BeforeEach(func() {
+				app = apps.Create(user, "--no-remote")
+				configs.Set(user, app, "DEIS_KUBERNETES_DEPLOYMENTS", "1")
+				builds.Create(user, app)
+			})
+
+			AfterEach(func() {
+				apps.Destroy(user, app)
+			})
+
+			Specify("that user can list that app's releases", func() {
+				sess, err := cmd.Start("deis releases:list -a %s", &user, app.Name)
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Releases", app.Name))
+				Eventually(sess).Should(Say(`v1\s+.*\s+%s created initial release`, user.Username))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+			Specify("that user can get info on one of the app's releases", func() {
+				sess, err := cmd.Start("deis releases:info v2 -a %s", &user, app.Name)
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Release v2", app.Name))
+				Eventually(sess).Should(Say(`config:\s+[\w-]+`))
+				Eventually(sess).Should(Say(`owner:\s+%s`, user.Username))
+				Eventually(sess).Should(Say(`summary:\s+%s \w+`, user.Username))
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Exit(0))
+			})
+
+			Context("and that app has three releases", func() {
+
+				BeforeEach(func() {
+					builds.Create(user, app)
+				})
+
+				Specify("that user can roll the application back to the second release", func() {
+					// rollback to v3 instead of v2 since v2 is a DEIS_KUBERNETES_DEPLOYMENTS without a build
+					sess, err := cmd.Start("deis releases:rollback v3 -a %s", &user, app.Name)
+					Eventually(sess).Should(Say(`Rolling back to`))
+					Eventually(sess, settings.MaxEventuallyTimeout).Should(Say(`...done`))
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(Exit(0))
+
+					sess, err = cmd.Start("deis releases:info v3 -a %s", &user, app.Name)
+					Eventually(sess, settings.MaxEventuallyTimeout).Should(Say("=== %s Release v3", app.Name))
+					Eventually(sess).Should(Say(`config:\s+[\w-]+`))
+					Eventually(sess).Should(Say(`owner:\s+%s`, user.Username))
+					Eventually(sess).Should(Say(`summary:\s+%s \w+`, user.Username))
+
+					// The updated date has to match a string like 2015-12-22T21:20:31Z:
+					Eventually(sess).Should(Say(`updated:\s+[\w\-\:]+Z`))
+					Eventually(sess).Should(Say(`uuid:\s+[0-9a-f\-]+`))
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(Exit(0))
+				})
+
+			})
+
+		})
+
+	})
+
+})


### PR DESCRIPTION
Should be eventually removed

Requires deis/controller#854

Adds a `config:set` cmd that allows us to set `DEIS_KUBERNETES_DEPLOYMENTS=1` as needed