### PR TITLE
fix(builds_test): relax matches for bad docker image specs

### DIFF
--- a/tests/builds_test.go
+++ b/tests/builds_test.go
@@ -78,14 +78,14 @@ var _ = Describe("deis builds", func() {
 				sess, err := cmd.Start("deis pull --app=%s %s", &user, app.Name, nonexistentImage)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(sess).Should(Say("Creating build..."))
-				Eventually(sess.Err).Should(Say("image %s not found", nonexistentImage))
+				Eventually(sess.Err).Should(Say(`image .* not found`))
 				Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(1))
 				// quay.io gives a "permission denied" 400 error
 				nonexistentImage = "quay.io/deis/nonexistent:dummy"
 				sess, err = cmd.Start("deis pull --app=%s %s", &user, app.Name, nonexistentImage)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(sess).Should(Say("Creating build..."))
-				Eventually(sess.Err).Should(Say("Permission Denied attempting to pull image %s", nonexistentImage))
+				Eventually(sess.Err).Should(Say("Permission Denied attempting to pull image"))
 				Eventually(sess, settings.MaxEventuallyTimeout).Should(Exit(1))
 			})
 


### PR DESCRIPTION
The specific error message varies between Kubernetes 1.2.5 and 1.3.0 and probably also on the underlying Docker version. I upgraded my GKE cluster and found that this spec breaks because 1.2.5 mentioned `deis/nonexistent:dummy` and 1.3.0 mentions `deis/nonexistent` (no tag).