### PR TITLE
fix(docker-test-integration.sh): actually override CLI_VERSION

### DIFF
--- a/docker-test-integration.sh
+++ b/docker-test-integration.sh
@@ -2,15 +2,16 @@
 #
 # This program is suppsoed to be run inside the workflow-e2e docker container
 # to download the workflow CLI at runtime and run the integration tests.
+set -eo pipefail
 
 BASE_URL="https://storage.googleapis.com/workflow-cli"
-URL="$BASE_URL/deis-latest-linux-amd64"
+URL="${BASE_URL}/deis-latest-linux-amd64"
 
-if [[ $CLI_VERSION -ne "latest" ]]; then
-	URL="$BASE_URL/$CLI_VERSION/deis-$CLI_VERSION-linux-amd64"
+if [[ "${CLI_VERSION}" != "latest" ]]; then
+	URL="${BASE_URL}/${CLI_VERSION}/deis-${CLI_VERSION}-linux-amd64"
 fi
 
-echo "Installing Workflow CLI version $CLI_VERSION"
-curl $URL -o /usr/local/bin/deis && chmod +x /usr/local/bin/deis
+echo "Installing Workflow CLI version '${CLI_VERSION}' via url '${URL}'"
+curl "${URL}" -f -o /usr/local/bin/deis && chmod +x /usr/local/bin/deis
 
 make test-integration


### PR DESCRIPTION
It appears `CLI_VERSION` other than `latest` was not being used,
due to the `-ne` check.  Also added `-f` flag to `curl` command
to echo failures and exit non-zero if the url is not valid, etc.

Closes https://github.com/deis/workflow-e2e/issues/256
Requires https://github.com/deis/jenkins-jobs/pull/147
Requires https://github.com/deis/charts/pull/306