### PR TITLE
fix(Makefile): wrap FOCUS_TEST in quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ export GINKO_NODES_ARG=-p
 endif
 
 ifdef FOCUS_TEST
-FOCUS_OPTS := --focus="${FOCUS_TEST}"
+FOCUS_OPTS := --focus="\"${FOCUS_TEST}\""
 endif
 
 ifdef SKIP_TEST


### PR DESCRIPTION
Wrapping in quotes to ensure a multi-word focus is used properly:

w/o this fix (all specs run -- we currently have a subset marked pending):
```
$ FOCUS_TEST="deis config" make docker-test-integration
docker run --rm -e GINKGO_NODES=15 -e SKIP_OPTS=--skip="all (buildpack|dockerfile) apps" -e FOCUS_OPTS=--focus="deis config" -e DEIS_CONTROLLER_URL= -e DEIS_ROUTER_SERVICE_HOST=146.148.64.213 -e DEIS_ROUTER_SERVICE_PORT=80 -e DEFAULT_EVENTUALLY_TIMEOUT= -e MAX_EVENTUALLY_TIMEOUT= -e JUNIT= -e DEBUG= -e CLI_VERSION=latest -v /Users/vaughndice/.kube:/root/.kube -w /go/src/github.com/deis/workflow-e2e quay.io/vdice/workflow-e2e:git-81d2b38 ./docker-test-integration.sh
Installing Workflow CLI version 'latest' via url 'https://storage.googleapis.com/workflow-cli/deis-latest-linux-amd64'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 7491k  100 7491k    0     0  5071k      0  0:00:01  0:00:01 --:--:-- 5271k
fatal: Not a git repository (or any of the parent directories): .git
ginkgo -slowSpecThreshold=120.00 -noisyPendings=false -nodes=15 --skip="all (buildpack|dockerfile) apps" --focus=deis config tests/


Running Suite: Deis Workflow
============================
Random Seed: 1469567031
Will run 271 of 306 specs
```

w this fix (subset of 'deis config' specs run):
```
$ FOCUS_TEST="deis config" make docker-test-integration
docker run --rm -e GINKGO_NODES=15 -e SKIP_OPTS=--skip="all (buildpack|dockerfile) apps" -e FOCUS_OPTS=--focus="\"deis config\"" -e DEIS_CONTROLLER_URL= -e DEIS_ROUTER_SERVICE_HOST=146.148.64.213 -e DEIS_ROUTER_SERVICE_PORT=80 -e DEFAULT_EVENTUALLY_TIMEOUT= -e MAX_EVENTUALLY_TIMEOUT= -e JUNIT= -e DEBUG= -e CLI_VERSION=latest -v /Users/vaughndice/.kube:/root/.kube -w /go/src/github.com/deis/workflow-e2e quay.io/vdice/workflow-e2e:git-81d2b38 ./docker-test-integration.sh
Installing Workflow CLI version 'latest' via url 'https://storage.googleapis.com/workflow-cli/deis-latest-linux-amd64'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 7491k  100 7491k    0     0  1742k      0  0:00:04  0:00:04 --:--:-- 1767k
fatal: Not a git repository (or any of the parent directories): .git
ginkgo -slowSpecThreshold=120.00 -noisyPendings=false -nodes=15 --skip="all (buildpack|dockerfile) apps" --focus="deis config" tests/

Running Suite: Deis Workflow
============================
Random Seed: 1469567123
Will run 54 of 306 specs
```