### PR TITLE
feat(procfile): create a build with a procfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,12 +62,12 @@ docker-bootstrap:
 test-integration:
 	ginkgo ${TEST_OPTS} tests/
 
-test-buildpacks: check-controller-url
+test-buildpacks:
 	ginkgo --focus="all buildpack apps" tests
 
-test-dockerfiles: check-controller-url
+test-dockerfiles:
 	ginkgo --focus="all dockerfile apps" tests
-	
+
 docker-build:
 	docker build -t ${IMAGE} ${CURDIR}
 	docker tag ${IMAGE} ${MUTABLE_IMAGE}

--- a/tests/buildprocfile_test.go
+++ b/tests/buildprocfile_test.go
@@ -1,0 +1,70 @@
+package tests
+
+import (
+	"time"
+
+	"github.com/deis/workflow-e2e/tests/cmd"
+	"github.com/deis/workflow-e2e/tests/cmd/apps"
+	"github.com/deis/workflow-e2e/tests/cmd/auth"
+	"github.com/deis/workflow-e2e/tests/model"
+	"github.com/deis/workflow-e2e/tests/settings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("deis builds procfile", func() {
+
+	Context("with an existing user", func() {
+
+		var user model.User
+
+		BeforeEach(func() {
+			user = auth.Register()
+		})
+
+		AfterEach(func() {
+			auth.Cancel(user)
+		})
+
+		Context("who owns an existing app that has not been deployed", func() {
+
+			var app model.App
+
+			BeforeEach(func() {
+				app = apps.Create(user, "--no-remote")
+			})
+
+			AfterEach(func() {
+				apps.Destroy(user, app)
+			})
+
+			Specify("that user create a new build of that app with a different procfile", func() {
+				// Docker Hub gives a "not found" 400 error
+				Image := "smothiki/exampleapp:latest"
+				procfile := "web: /bin/boot"
+				sess, err := cmd.Start("deis pull %s --app=%s ", &user, Image, app.Name)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Say("Creating build..."))
+				time.Sleep(30000 * time.Millisecond)
+				sess, err = cmd.Start("deis builds:create %s -a %s --procfile \"%s\"", &user, Image, app.Name, procfile)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Say("Creating build..."))
+				time.Sleep(20000 * time.Millisecond)
+				sess, err = cmd.Start("deis ps:scale web=1 -a %s", &user, app.Name)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(Say("Scaling processes... but first,"))
+				time.Sleep(20000 * time.Millisecond)
+				Eventually(sess, settings.MaxEventuallyTimeout).Should(Say(`done in \d+s`))
+				Eventually(sess).Should(Say("=== %s Processes", app.Name))
+				Eventually(sess).Should(Say("--- %s:", "web"))
+				Eventually(sess).Should(Say(`(%s-v\d+-[\w-]+) up \(v\d+\)`, app.Name))
+
+			})
+
+		})
+
+	})
+
+})


### PR DESCRIPTION
test to check builds with a different procfile
refer https://github.com/deis/workflow-e2e/issues/202
flow of steps 
```
$ deis pull deis/example-dockerfile-http -a test1
Creating build... done
smothikis-MacBook-Pro:deis smothiki$ deis apps:info -a test1
=== test1 Application
updated:  2016-07-27T22:23:56Z
uuid:     8c72de40-c9b9-4322-ab58-b6b771ad45e0
created:  2016-07-27T22:23:25Z
url:      test1.104.154.49.56.nip.io
owner:    sm
id:       test1

=== test1 Processes
--- cmd:
test1-v2-cmd-q6o7a up (v2)

=== test1 Domains
test1

smothikis-MacBook-Pro:deis smothiki$ kubectl get pods --namespace=test1
NAME                 READY     STATUS    RESTARTS   AGE
test1-v2-cmd-q6o7a   1/1       Running   0          4m
(reverse-i-search)`deis ': deis apps:info -a test1
smothikis-MacBook-Pro:deis smothiki$ deis builds:create deis/example-dockerfile-http -a test1 --procfile "web: /bin/boot"
Creating build... done
smothikis-MacBook-Pro:deis smothiki$ kubectl get rc --namespace=test1
NAME           DESIRED   CURRENT   AGE
test1-v3-cmd   1         1         26s
smothikis-MacBook-Pro:deis smothiki$ deis scale web=1 -a test1
Scaling processes... but first, coffee!
done in 2s
=== test1 Processes
--- cmd:
test1-v3-cmd-46c8q up (v3)
--- web:
test1-v3-web-8qow1 terminating (v3)
```