### PR TITLE
fix(Makefile): add retrying to workflow CLI download

### DIFF
--- a/docker-test-integration.sh
+++ b/docker-test-integration.sh
@@ -11,8 +11,11 @@ if [[ "${CLI_VERSION}" != "latest" ]]; then
 	URL="${BASE_URL}/${CLI_VERSION}/deis-${CLI_VERSION}-linux-amd64"
 fi
 
+# Download CLI, retry up to 5 times with 10 second delay between each
 echo "Installing Workflow CLI version '${CLI_VERSION}' via url '${URL}'"
-curl -s "${URL}" -f -o /usr/local/bin/deis && chmod +x /usr/local/bin/deis
+curl --silent -I "${URL}"
+curl --silent --retry 5 --retry-delay 10 -o /usr/local/bin/deis "${URL}"
+chmod +x /usr/local/bin/deis
 
 echo "Workflow CLI Version '$(deis --version)' installed."
 


### PR DESCRIPTION
Also run chmod as a separate command as conditionals negate exit on error that -e is trying to provide
This should prevent the CI system form continuing when there is a problem downloading the CLI and also should let GCS settle down a bit after the binary is uploaded by providing the retry and some preprive (10 seconds) between each retry