### PR TITLE
fix(docker-test-integration.sh): explicit DEBUG_MODE check

### DIFF
--- a/docker-test-integration.sh
+++ b/docker-test-integration.sh
@@ -5,7 +5,7 @@
 set -eo pipefail
 
 function debug {
-	if [ ! -z "${DEBUG_MODE}" ]; then
+	if [ "${DEBUG_MODE}" == "true" ]; then
 		filename="/tmp/deis_debug"
 		touch "${filename}"
 		echo "Sleeping until ${filename} is deleted"


### PR DESCRIPTION
Must be set to `true` to enable DEBUG_MODE.  

The default in the [chart](https://github.com/deis/workflow-e2e/blob/master/charts/workflow-e2e/values.yaml#L8) is `false`, which paired with previous logic simply checking if non-empty, meant debug mode was being run when not intended.